### PR TITLE
Add catch up for secondary instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocksdb-py"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 description = "Python bindings for RocksDB"
 
@@ -9,5 +9,5 @@ name = "rocksdbpy"
 crate-type = ["cdylib"]
 
 [dependencies]
-rocksdb = { version = "0.21.0", features = ["snappy", "lz4", "zstd", "zlib", "bzip2"] }
+rocksdb = { version = "0.23.0", features = ["snappy", "lz4", "zstd", "zlib", "bzip2"] }
 pyo3 = { version = "0.19.2", features = ["extension-module"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocksdb-py"
-version = "0.0.5"
+version = "0.0.6"
 readme = "readme.md"
 homepage = "https://github.com/trk54ylmz/rocksdb-py"
 repository = "https://github.com/trk54ylmz/rocksdb-py"

--- a/rocksdbpy.pyi
+++ b/rocksdbpy.pyi
@@ -140,13 +140,19 @@ class RocksDB:
         """
         ...
 
-    def flush(self):
+    def flush(self) -> None:
         """
         Flushes database memtables to SST files on the disk using default options.
         """
         ...
 
-    def close(self):
+    def try_catch_up_with_primary(self) -> None:
+        """
+        Tries to catch up with the primary database.
+        """
+        ...
+
+    def close(self) -> None:
         """
         Close active database
         """

--- a/src/db.rs
+++ b/src/db.rs
@@ -259,6 +259,27 @@ impl DBPy {
         }
     }
 
+    /// Try to catch up with the primary by applying all the oplog entries.
+    /// This function is only useful for secondary instances.
+    ///
+    /// # Example
+    /// ```
+    /// db.try_catch_up_with_primary()
+    /// ```
+    fn try_catch_up_with_primary(&self) -> PyResult<()> {
+        if let Some(db) = &self.db {
+            match db.try_catch_up_with_primary() {
+                Ok(_) => Ok(()),
+                Err(e) => Err(RocksDBPyException::new_err(format!(
+                    "Database cannot catch up with primary. {}",
+                    e,
+                ))),
+            }
+        } else {
+            Err(RocksDBPyException::new_err("Database cannot catch up with primary"))
+        }
+    }
+
     /// Close active database
     ///
     /// # Example


### PR DESCRIPTION
Without this, the secondary instance is not really useful (not that different from read-only).

Also bumped package and rocksdb version.