### PR TITLE
More RocksDB Options

### DIFF
--- a/src/option.rs
+++ b/src/option.rs
@@ -1233,4 +1233,20 @@ impl OptionPy {
     pub fn set_dump_malloc_stats(&mut self, enabled: bool) {
         self.inner.set_dump_malloc_stats(enabled)
     }
+
+    /// Enable whole key bloom filter in memtable. Note this will only take effect if
+    /// `memtable_prefix_bloom_size_ratio` is not 0. Enabling whole key filtering can potentially
+    /// reduce CPU usage for point-look-ups.
+    /// 
+    /// Dynamically changeable through `SetOptions()` API
+    /// 
+    /// Default: `false (disable)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_memtable_whole_key_filtering(true)
+    /// ```
+    pub fn set_memtable_whole_key_filtering(&mut self, whole_key_filter: bool) {
+        self.inner.set_memtable_whole_key_filtering(whole_key_filter)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -930,4 +930,17 @@ impl OptionPy {
     pub fn set_stats_persist_period_sec(&mut self, period: u32) {
         self.inner.set_stats_persist_period_sec(period)
     }
+
+    /// When set to `true`, reading SST files will opt out of the filesystem's readahead.
+    /// Setting this to false may improve sequential iteration performance.
+    /// 
+    /// Default: `true`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_advise_random_on_open(false)
+    /// ```
+    pub fn set_advise_random_on_open(&mut self, advise: bool) {
+        self.inner.set_advise_random_on_open(advise)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -431,4 +431,20 @@ impl OptionPy {
     pub fn set_bottommost_compression_options(&mut self, w_bits: i32, level: i32, strategy: i32, max_dict_bytes: i32, enabled: bool) {
         self.inner.set_bottommost_compression_options(w_bits, level, strategy, max_dict_bytes, enabled)
     }
+
+    /// Sets maximum size of training data passed to zstd's dictionary trainer. Using zstd's
+    /// dictionary trainer can achieve even better compression ratio improvements than
+    /// using `max_dict_bytes` alone.
+    /// 
+    /// The training data will be used to generate a dictionary of `max_dict_bytes`.
+    ///
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_zstd_max_train_bytes(64 * 1024 * 1024)
+    /// ```
+    pub fn set_zstd_max_train_bytes(&mut self, value: i32) {
+        self.inner.set_zstd_max_train_bytes(value)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1354,4 +1354,14 @@ impl OptionPy {
     pub fn set_write_dbid_to_manifest(&mut self, val: bool) {
         self.inner.set_write_dbid_to_manifest(val)
     }
+
+    /// Returns the value of the `write_dbid_to_manifest` option.
+    /// 
+    /// Examples
+    /// ```
+    /// opts.get_write_dbid_to_manifest()
+    /// ```
+    pub fn get_write_dbid_to_manifest(&self) -> bool {
+        return self.inner.get_write_dbid_to_manifest()
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -736,4 +736,17 @@ impl OptionPy {
     pub fn set_max_bytes_for_level_base(&mut self, size: u64) {
         self.inner.set_max_bytes_for_level_base(size)
     }
+
+    /// The manifest file is rolled over on reaching this limit. The older manifest file be
+    /// deleted. The default value is `MAX_INT` so that roll-over does not take place.
+    /// 
+    /// Default: `MAX_INT (maximum integer value for architecture, 32 or 64 bit).`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_manifest_file_size(20 * 1024 * 1024)
+    /// ```
+    pub fn set_max_manifest_file_size(&mut self, size: usize) {
+        self.inner.set_max_manifest_file_size(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -491,4 +491,16 @@ impl OptionPy {
     pub fn set_level_compaction_dynamic_level_bytes(&mut self, enabled: bool) {
         self.inner.set_level_compaction_dynamic_level_bytes(enabled)
     }
+
+    /// Sets the `optimize_filters_for_hits` flag
+    ///
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_optimize_filters_for_hits(true)
+    /// ```
+    pub fn set_optimize_filters_for_hits(&mut self, optimize_for_hits: bool) {
+        self.inner.set_optimize_filters_for_hits(optimize_for_hits)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -534,4 +534,17 @@ impl OptionPy {
     pub fn prepare_for_bulk_load(&mut self) {
         self.inner.prepare_for_bulk_load()
     }
+
+    /// If `max_open_files` is -1, DB will open all files on `DB::Open()`. You can use this option
+    /// to increase the number of threads used to open the files.
+    ///
+    /// Default: `16`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_file_opening_threads(32)
+    /// ```
+    pub fn set_max_file_opening_threads(&mut self, nthreads: i32) {
+        self.inner.set_max_file_opening_threads(nthreads)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -749,4 +749,19 @@ impl OptionPy {
     pub fn set_max_manifest_file_size(&mut self, size: usize) {
         self.inner.set_max_manifest_file_size(size)
     }
+
+    /// Sets the number of files to trigger level-0 compaction. A value < 0 means that level-0
+    /// compaction will not be triggered by number of files at all.
+    /// 
+    /// Dynamically changeable through `SetOptions()` API
+    /// 
+    /// Default: `4`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_level_zero_file_num_compaction_trigger(8)
+    /// ```
+    pub fn set_level_zero_file_num_compaction_trigger(&mut self, n: i32) {
+        self.inner.set_level_zero_file_num_compaction_trigger(n)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -703,4 +703,20 @@ impl OptionPy {
     pub fn set_min_write_buffer_number(&mut self, nbuf: i32) {
         self.inner.set_min_write_buffer_number(nbuf)
     }
+
+    /// Amount of data to build up in memtables across all column families before writing to disk.
+    /// 
+    /// This is distinct from `write_buffer_size`, which enforces a limit for a single memtable.
+    /// 
+    /// This feature is disabled by default. Specify a non-zero value to enable it.
+    /// 
+    /// Default: `0 (disabled)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_write_buffer_size(128 * 1024 * 1024)
+    /// ```
+    pub fn set_db_write_buffer_size(&mut self, size: usize) {
+        self.inner.set_db_write_buffer_size(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1149,4 +1149,19 @@ impl OptionPy {
     pub fn set_max_log_file_size(&mut self, size: usize) {
         self.inner.set_max_log_file_size(size)
     }
+
+    /// Sets the time for the info log file to roll (in seconds).
+    /// 
+    /// If specified with non-zero value, log file will be rolled if it has been active longer
+    /// than `log_file_time_to_roll`.
+    /// 
+    /// Default: `0 (disabled)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_log_file_size(86_400)
+    /// ```
+    pub fn set_log_file_time_to_roll(&mut self, secs: usize) {
+        self.inner.set_log_file_time_to_roll(secs)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1265,4 +1265,23 @@ impl OptionPy {
     pub fn set_enable_blob_files(&mut self, val: bool) {
         self.inner.set_enable_blob_files(val)
     }
+
+    /// Set this option to true during creation of database if you want to be able to ingest behind
+    /// (call `IngestExternalFile()` skipping keys that already exist, rather than overwriting
+    /// matching keys). Setting this option to true has the following effects:
+    /// 
+    /// 1. Disable some internal optimizations around SST file compression.
+    /// 2. Reserve the last level for ingested files only.
+    /// 3. Compaction will not include any file from the last level.
+    /// 
+    /// Note that only Universal Compaction supports `allow_ingest_behind`.
+    /// `num_levels` should be >= 3 if this option is turned on.
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_allow_ingest_behind(true)
+    /// ```
+    pub fn set_allow_ingest_behind(&mut self, val: bool) {
+        self.inner.set_allow_ingest_behind(val)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1121,4 +1121,17 @@ impl OptionPy {
     pub fn set_ratelimiter(&mut self, rate_bytes_per_sec: i64, refill_period_us: i64, fairness: i32) {
         self.inner.set_ratelimiter(rate_bytes_per_sec, refill_period_us, fairness)
     }
+
+    /// Use to control write rate of flush and compaction. Flush has higher priority than
+    /// compaction. If rate limiter is enabled, `bytes_per_sync` is set to 1MB by default.
+    /// 
+    /// Default: `disable`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_auto_tuned_ratelimiter(true)
+    /// ```
+    pub fn set_auto_tuned_ratelimiter(&mut self, rate_bytes_per_sec: i64, refill_period_us: i64, fairness: i32) {
+        self.inner.set_auto_tuned_ratelimiter(rate_bytes_per_sec, refill_period_us, fairness)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1116,7 +1116,7 @@ impl OptionPy {
     ///
     /// Examples
     /// ```
-    /// opts.set_ratelimiter(true)
+    /// opts.set_ratelimiter(1024 * 1024, 100 * 1000, 10)
     /// ```
     pub fn set_ratelimiter(&mut self, rate_bytes_per_sec: i64, refill_period_us: i64, fairness: i32) {
         self.inner.set_ratelimiter(rate_bytes_per_sec, refill_period_us, fairness)
@@ -1129,7 +1129,7 @@ impl OptionPy {
     ///
     /// Examples
     /// ```
-    /// opts.set_auto_tuned_ratelimiter(true)
+    /// opts.set_auto_tuned_ratelimiter(1024 * 1024, 100 * 1000, 10)
     /// ```
     pub fn set_auto_tuned_ratelimiter(&mut self, rate_bytes_per_sec: i64, refill_period_us: i64, fairness: i32) {
         self.inner.set_auto_tuned_ratelimiter(rate_bytes_per_sec, refill_period_us, fairness)

--- a/src/option.rs
+++ b/src/option.rs
@@ -290,4 +290,27 @@ impl OptionPy {
     pub fn increase_parallelism(&mut self, parallelism: i32) {
         self.inner.increase_parallelism(parallelism)
     }
+
+    /// Optimize level style compaction.
+    /// 
+    /// Default values for some parameters in `Options`` are not optimized for heavy workloads and
+    /// big datasets, which means you might observe write stalls under some conditions.
+    /// 
+    /// This can be used as one of the starting points for tuning RocksDB options in such cases.
+    /// 
+    /// Internally, it sets `write_buffer_size`, `min_write_buffer_number_to_merge`,
+    /// `max_write_buffer_number`, `level0_file_num_compaction_trigger`, `target_file_size_base`,
+    /// `max_bytes_for_level_base`, so it can override if those parameters were set before.
+    ///
+    /// It sets buffer sizes so that memory consumption would be constrained by `memtable_memory_budget`.
+    ///
+    /// Default: `0x4000000`
+    ///
+    /// Examples
+    /// ```
+    /// opts.optimize_level_style_compaction(64 * 1024 * 1024)
+    /// ```
+    pub fn optimize_level_style_compaction(&mut self, memtable_memory_budget: usize) {
+        self.inner.optimize_level_style_compaction(memtable_memory_budget)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -764,4 +764,22 @@ impl OptionPy {
     pub fn set_level_zero_file_num_compaction_trigger(&mut self, n: i32) {
         self.inner.set_level_zero_file_num_compaction_trigger(n)
     }
+
+    /// `SetMemtableHugePageSize` sets the page size for huge page for arena used by the memtable.
+    /// If <=0, it won't allocate from huge page but from malloc. Users are responsible to reserve
+    /// huge pages for it to be allocated. For example: `sysctl -w vm.nr_hugepages=20` See linux
+    /// doc `Documentation/vm/hugetlbpage.txt` If there isn't enough free huge page available, it
+    /// will fall back to malloc.
+    /// 
+    /// Dynamically changeable through SetOptions() API
+    /// 
+    /// Default: `N/A`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_memtable_huge_page_size(20)
+    /// ```
+    pub fn set_memtable_huge_page_size(&mut self, size: usize) {
+        self.inner.set_memtable_huge_page_size(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -906,4 +906,16 @@ impl OptionPy {
     pub fn set_max_total_wal_size(&mut self, size: u64) {
         self.inner.set_max_total_wal_size(size)
     }
+
+    /// If not zero, dump `rocksdb.stats` to LOG every `stats_dump_period_sec`.
+    /// 
+    /// Default: `600 (10 mins)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_stats_dump_period_sec(300)
+    /// ```
+    pub fn set_stats_dump_period_sec(&mut self, period: u32) {
+        self.inner.set_stats_dump_period_sec(period)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1221,4 +1221,16 @@ impl OptionPy {
     pub fn set_arena_block_size(&mut self, size: usize) {
         self.inner.set_arena_block_size(size)
     }
+
+    /// If `true`, then print malloc stats together with `rocksdb.stats` when printing to LOG.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_dump_malloc_stats(true)
+    /// ```
+    pub fn set_dump_malloc_stats(&mut self, enabled: bool) {
+        self.inner.set_dump_malloc_stats(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -626,4 +626,21 @@ impl OptionPy {
     pub fn set_max_sequential_skip_in_iterations(&mut self, num: u64) {
         self.inner.set_max_sequential_skip_in_iterations(num)
     }
+
+    /// Enable direct I/O mode for reading they may or may not improve performance depending on
+    /// the use case
+    /// 
+    /// Files will be opened in "direct I/O" mode which means that data read from the disk will not
+    /// be cached or buffered. The hardware buffer of the devices may however still be used.
+    /// Memory mapped files are not impacted by these parameters.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_use_direct_reads(true)
+    /// ```
+    pub fn set_use_direct_reads(&mut self, enabled: bool) {
+        self.inner.set_use_direct_reads(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1078,4 +1078,17 @@ impl OptionPy {
     pub fn set_allow_mmap_writes(&mut self, is_enabled: bool) {
         self.inner.set_allow_mmap_writes(is_enabled)
     }
+
+    /// If enabled, WAL is not flushed automatically after each write. Instead it relies on manual
+    /// invocation of `DB::flush_wal()` to write the WAL buffer to its file.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_manual_wal_flush(true)
+    /// ```
+    pub fn set_manual_wal_flush(&mut self, is_enabled: bool) {
+        self.inner.set_manual_wal_flush(is_enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1040,4 +1040,18 @@ impl OptionPy {
     pub fn set_manifest_preallocation_size(&mut self, size: usize) {
         self.inner.set_manifest_preallocation_size(size)
     }
+
+    /// If true, then `DB::Open()` will not update the statistics used to optimize compaction
+    /// decision by loading table properties from many files. Turning off this feature will
+    /// improve DBOpen time especially in disk environment.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_manifest_preallocation_size(true)
+    /// ```
+    pub fn set_skip_stats_update_on_db_open(&mut self, skip: bool) {
+        self.inner.set_skip_stats_update_on_db_open(skip)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -595,4 +595,19 @@ impl OptionPy {
     pub fn set_allow_concurrent_memtable_write(&mut self, allow: bool) {
         self.inner.set_allow_concurrent_memtable_write(allow)
     }
+
+    /// If true, threads synchronizing with the write batch group leader will wait for up to
+    /// `write_thread_max_yield_usec` before blocking on a mutex. This can substantially improve
+    /// throughput for concurrent workloads, regardless
+    /// of whether `allow_concurrent_memtable_write` is enabled.
+    /// 
+    /// Default: `true`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_enable_write_thread_adaptive_yield(false)
+    /// ```
+    pub fn set_enable_write_thread_adaptive_yield(&mut self, enabled: bool) {
+        self.inner.set_enable_write_thread_adaptive_yield(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1181,4 +1181,17 @@ impl OptionPy {
     pub fn set_recycle_log_file_num(&mut self, num: usize) {
         self.inner.set_recycle_log_file_num(num)
     }
+
+    /// Sets the threshold at which all writes will be slowed down to at least `delayed_write_rate`
+    /// if estimated bytes needed to be compaction exceed this threshold.
+    /// 
+    /// Default: `64GB`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_soft_pending_compaction_bytes_limit(96 * 1024 * 1024 * 1024)
+    /// ```
+    pub fn set_soft_pending_compaction_bytes_limit(&mut self, limit: usize) {
+        self.inner.set_soft_pending_compaction_bytes_limit(limit)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -547,4 +547,18 @@ impl OptionPy {
     pub fn set_max_file_opening_threads(&mut self, nthreads: i32) {
         self.inner.set_max_file_opening_threads(nthreads)
     }
+
+    /// Same as bytes_per_sync, but applies to WAL files.
+    ///
+    /// Dynamically changeable through `SetDBOptions()` API.
+    /// 
+    /// Default: `0, turned off`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_wal_bytes_per_sync(1 * 1024 * 1024)
+    /// ```
+    pub fn set_wal_bytes_per_sync(&mut self, nbytes: u64) {
+        self.inner.set_wal_bytes_per_sync(nbytes)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1325,4 +1325,14 @@ impl OptionPy {
     pub fn set_track_and_verify_wals_in_manifest(&mut self, val: bool) {
         self.inner.set_track_and_verify_wals_in_manifest(val)
     }
+
+    /// Returns the value of the `track_and_verify_wals_in_manifest` option.
+    /// 
+    /// Examples
+    /// ```
+    /// opts.get_track_and_verify_wals_in_manifest()
+    /// ```
+    pub fn get_track_and_verify_wals_in_manifest(&self) -> bool {
+        return self.inner.get_track_and_verify_wals_in_manifest()
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -643,4 +643,21 @@ impl OptionPy {
     pub fn set_use_direct_reads(&mut self, enabled: bool) {
         self.inner.set_use_direct_reads(enabled)
     }
+
+    /// Enable direct I/O mode for flush and compaction
+    /// 
+    /// Files will be opened in "direct I/O" mode which means that data written to the disk will
+    /// not be cached or buffered. The hardware buffer of the devices may however still be used.
+    /// Memory mapped files are not impacted by these parameters. they may or may not improve
+    /// performance depending on the use case
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_use_direct_io_for_flush_and_compaction(true)
+    /// ```
+    pub fn set_use_direct_io_for_flush_and_compaction(&mut self, enabled: bool) {
+        self.inner.set_use_direct_io_for_flush_and_compaction(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1249,4 +1249,20 @@ impl OptionPy {
     pub fn set_memtable_whole_key_filtering(&mut self, whole_key_filter: bool) {
         self.inner.set_memtable_whole_key_filtering(whole_key_filter)
     }
+
+    /// Enable the use of key-value separation.
+    /// 
+    /// More details can be found here: [Integrated BlobDB](https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html).
+    /// 
+    /// Dynamically changeable through `SetOptions()` API
+    /// 
+    /// Default: `false (disable)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_enable_blob_files(true)
+    /// ```
+    pub fn set_enable_blob_files(&mut self, val: bool) {
+        self.inner.set_enable_blob_files(val)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1194,4 +1194,17 @@ impl OptionPy {
     pub fn set_soft_pending_compaction_bytes_limit(&mut self, limit: usize) {
         self.inner.set_soft_pending_compaction_bytes_limit(limit)
     }
+
+    /// Sets the bytes threshold at which all writes are stopped if estimated bytes needed to be
+    /// compaction exceed this threshold.
+    /// 
+    /// Default: `256GB`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_hard_pending_compaction_bytes_limit(512 * 1024 * 1024 * 1024)
+    /// ```
+    pub fn set_hard_pending_compaction_bytes_limit(&mut self, limit: usize) {
+        self.inner.set_hard_pending_compaction_bytes_limit(limit)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -958,4 +958,18 @@ impl OptionPy {
     pub fn set_use_adaptive_mutex(&mut self, enabled: bool) {
         self.inner.set_use_adaptive_mutex(enabled)
     }
+
+    /// When a prefix_extractor is defined through `opts.set_prefix_extractor` this creates a
+    /// prefix bloom filter for each memtable with the size of
+    /// `write_buffer_size * memtable_prefix_bloom_ratio` (capped at 0.25).
+    /// 
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_memtable_prefix_bloom_ratio(0.2)
+    /// ```
+    pub fn set_memtable_prefix_bloom_ratio(&mut self, ratio: f64) {
+        self.inner.set_memtable_prefix_bloom_ratio(ratio)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -518,4 +518,20 @@ impl OptionPy {
     pub fn set_delete_obsolete_files_period_micros(&mut self, micros: u64) {
         self.inner.set_delete_obsolete_files_period_micros(micros)
     }
+
+    /// Prepare the DB for bulk loading.
+    /// 
+    /// All data will be in level 0 without any automatic compaction. It's recommended to manually
+    /// call `CompactRange(NULL, NULL)` before reading from the database, because otherwise the
+    /// read can be very slow.
+    ///
+    /// Default: `N/A`
+    ///
+    /// Examples
+    /// ```
+    /// opts.prepare_for_bulk_load()
+    /// ```
+    pub fn prepare_for_bulk_load(&mut self) {
+        self.inner.prepare_for_bulk_load()
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -719,4 +719,21 @@ impl OptionPy {
     pub fn set_db_write_buffer_size(&mut self, size: usize) {
         self.inner.set_db_write_buffer_size(size)
     }
+
+    /// Control maximum total data size for a level. `max_bytes_for_level_base` is the max total
+    /// for level-1. Maximum number of bytes for level L can be calculated as
+    /// (`max_bytes_for_level_base`) * (`max_bytes_for_level_multiplier` ^ (L-1))
+    /// For example, if `max_bytes_for_level_base` is 200MB,
+    /// and if `max_bytes_for_level_multiplier` is 10, total data size for level-1 will be 200MB,
+    /// total file size for level-2 will be 2GB, and total file size for level-3 will be 20GB.
+    /// 
+    /// Default: `0x10000000 (256MiB).`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_write_buffer_size(512 * 1024 * 1024)
+    /// ```
+    pub fn set_max_bytes_for_level_base(&mut self, size: u64) {
+        self.inner.set_max_bytes_for_level_base(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -828,4 +828,36 @@ impl OptionPy {
     pub fn set_inplace_update_locks(&mut self, num: usize) {
         self.inner.set_inplace_update_locks(num)
     }
+
+    /// The total maximum size(bytes) of write buffers to maintain in memory including copies of
+    /// buffers that have already been flushed. This parameter only affects trimming of flushed
+    /// buffers and does not affect flushing. This controls the maximum amount of write history
+    /// that will be available in memory for conflict checking when Transactions are used. The
+    /// actual size of write history (flushed Memtables) might be higher than this limit if
+    /// further trimming will reduce write history total size below this limit.
+    /// For example, if `max_write_buffer_size_to_maintain` is set to 64MB, and there are three
+    /// flushed Memtables, with sizes of 32MB, 20MB, 20MB. Because trimming the next Memtable of
+    /// size 20MB will reduce total memory usage to 52MB which is below the limit, RocksDB
+    /// will stop trimming.
+    /// 
+    /// When using an OptimisticTransactionDB: If this value is too low, some transactions may fail
+    /// at commit time due to not being able to determine whether there were any write conflicts.
+    /// 
+    /// When using a TransactionDB: If `Transaction::SetSnapshot` is used, TransactionDB will read
+    /// either in-memory write buffers or SST files to do write-conflict checking. Increasing this
+    /// value can reduce the number of reads to SST files done for conflict detection.
+    /// 
+    /// Setting this value to 0 will cause write buffers to be freed immediately after
+    /// they are flushed. If this value is set to -1, `max_write_buffer_number * write_buffer_size`
+    /// will be used.
+    /// 
+    /// Default: `If using a TransactionDB/OptimisticTransactionDB, the default value will be set to the value of 'max_write_buffer_number * write_buffer_size' if it is not explicitly set by the user. Otherwise, the default is 0.`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_write_buffer_size_to_maintain(20_000)
+    /// ```
+    pub fn set_max_write_buffer_size_to_maintain(&mut self, size: i64) {
+        self.inner.set_max_write_buffer_size_to_maintain(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -349,4 +349,16 @@ impl OptionPy {
     pub fn create_missing_column_families(&mut self, create_missing_cfs: bool) {
         self.inner.create_missing_column_families(create_missing_cfs)
     }
+
+    /// Specifies whether an error should be raised if the database already exists.
+    ///
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_error_if_exists(true)
+    /// ```
+    pub fn set_error_if_exists(&mut self, enabled: bool) {
+        self.inner.set_error_if_exists(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1302,4 +1302,27 @@ impl OptionPy {
     pub fn set_avoid_unnecessary_blocking_io(&mut self, val: bool) {
         self.inner.set_avoid_unnecessary_blocking_io(val)
     }
+
+    /// If true, the log numbers and sizes of the synced WALs are tracked in MANIFEST. During DB
+    /// recovery, if a synced WAL is missing from disk, or the WAL's size does not match the
+    /// recorded size in MANIFEST, an error will be reported and the recovery will be aborted.
+    /// 
+    /// This is one additional protection against WAL corruption besides
+    /// the per-WAL-entry checksum.
+    /// 
+    /// Note that this option does not work with secondary instance. Currently, only syncing closed
+    /// WALs are tracked. Calling `DB::SyncWAL()`, etc. or writing with `WriteOptions::sync=true`
+    /// to sync the live WAL is not tracked for performance/efficiency reasons.
+    /// 
+    /// See: https://github.com/facebook/rocksdb/wiki/Track-WAL-in-MANIFEST
+    /// 
+    /// Default: `false (disabled)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_track_and_verify_wals_in_manifest(true)
+    /// ```
+    pub fn set_track_and_verify_wals_in_manifest(&mut self, val: bool) {
+        self.inner.set_track_and_verify_wals_in_manifest(val)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -672,4 +672,19 @@ impl OptionPy {
     pub fn set_is_fd_close_on_exec(&mut self, enabled: bool) {
         self.inner.set_is_fd_close_on_exec(enabled)
     }
+
+    /// By default `target_file_size_multiplier` is 1, which means by default files in different
+    /// levels will have similar size.
+    /// 
+    /// Dynamically changeable through `SetOptions()` API
+    /// 
+    /// Default: `1`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_target_file_size_multiplier(2)
+    /// ```
+    pub fn set_target_file_size_multiplier(&mut self, multiplier: i32) {
+        self.inner.set_target_file_size_multiplier(multiplier)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1207,4 +1207,18 @@ impl OptionPy {
     pub fn set_hard_pending_compaction_bytes_limit(&mut self, limit: usize) {
         self.inner.set_hard_pending_compaction_bytes_limit(limit)
     }
+
+    /// Sets the size of one block in arena memory allocation.
+    /// 
+    /// If <= 0, a proper value is automatically calculated (usually 1/10 of `writer_buffer_size`).
+    /// 
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_arena_block_size(32 * 1024 * 1024)
+    /// ```
+    pub fn set_arena_block_size(&mut self, size: usize) {
+        self.inner.set_arena_block_size(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -395,4 +395,26 @@ impl OptionPy {
     pub fn set_compression_options_parallel_threads(&mut self, num: i32) {
         self.inner.set_compression_options_parallel_threads(num)
     }
+
+    /// Maximum size of dictionaries used to prime the compression library. Enabling dictionary can
+    /// improve compression ratios when there are repetitions across data blocks.
+    ///
+    /// The dictionary is created by sampling the SST file data. If `zstd_max_train_bytes` is
+    /// nonzero, the samples are passed through zstd's dictionary generator. Otherwise, the random
+    /// samples are used directly as the dictionary.
+    ///
+    /// When compression dictionary is disabled, we compress and write each block before buffering
+    /// data for the next one. When compression dictionary is enabled, we buffer all SST file data
+    /// in-memory so we can sample it, as data can only be compressed and written after the
+    /// dictionary has been finalized. So users of this feature may see increased memory usage.
+    ///
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_compression_options(4, 5, 6, 7)
+    /// ```
+    pub fn set_compression_options(&mut self, w_bits: i32, level: i32, strategy: i32, max_dict_bytes: i32) {
+        self.inner.set_compression_options(w_bits, level, strategy, max_dict_bytes)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -799,4 +799,21 @@ impl OptionPy {
     pub fn set_max_successive_merges(&mut self, num: usize) {
         self.inner.set_max_successive_merges(num)
     }
+
+    /// Enable/disable thread-safe inplace updates.
+    /// 
+    /// Requires updates if
+    /// - key exists in current memtable
+    /// - new `sizeof(new_value)` <= `sizeof(old_value)`
+    /// - `old_value` for that key is a put i.e. `kTypeValue`
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_inplace_update_support(true)
+    /// ```
+    pub fn set_inplace_update_support(&mut self, enabled: bool) {
+        self.inner.set_inplace_update_support(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -880,4 +880,16 @@ impl OptionPy {
     pub fn set_enable_pipelined_write(&mut self, value: bool) {
         self.inner.set_enable_pipelined_write(value)
     }
+
+    /// Measure IO stats in compactions and flushes, if `true`.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_report_bg_io_stats(true)
+    /// ```
+    pub fn set_report_bg_io_stats(&mut self, enable: bool) {
+        self.inner.set_report_bg_io_stats(enable)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1066,4 +1066,16 @@ impl OptionPy {
     pub fn set_keep_log_file_num(&mut self, nfiles: usize) {
         self.inner.set_keep_log_file_num(nfiles)
     }
+
+    /// Allow the OS to mmap file for writing.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_allow_mmap_writes(true)
+    /// ```
+    pub fn set_allow_mmap_writes(&mut self, is_enabled: bool) {
+        self.inner.set_allow_mmap_writes(is_enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -892,4 +892,18 @@ impl OptionPy {
     pub fn set_report_bg_io_stats(&mut self, enable: bool) {
         self.inner.set_report_bg_io_stats(enable)
     }
+
+    /// Once write-ahead logs exceed this size, we will start forcing the flush of column families
+    /// whose memtables are backed by the oldest live WAL file (i.e. the ones that are causing all
+    /// the space amplification).
+    /// 
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_total_wal_size(1 << 30)
+    /// ```
+    pub fn set_max_total_wal_size(&mut self, size: u64) {
+        self.inner.set_max_total_wal_size(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1108,4 +1108,17 @@ impl OptionPy {
     pub fn set_atomic_flush(&mut self, atomic_flush: bool) {
         self.inner.set_atomic_flush(atomic_flush)
     }
+
+    /// Use to control write rate of flush and compaction. Flush has higher priority than
+    /// compaction. If rate limiter is enabled, `bytes_per_sync` is set to 1MB by default.
+    /// 
+    /// Default: `disable`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_ratelimiter(true)
+    /// ```
+    pub fn set_ratelimiter(&mut self, rate_bytes_per_sec: i64, refill_period_us: i64, fairness: i32) {
+        self.inner.set_ratelimiter(rate_bytes_per_sec, refill_period_us, fairness)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -417,4 +417,18 @@ impl OptionPy {
     pub fn set_compression_options(&mut self, w_bits: i32, level: i32, strategy: i32, max_dict_bytes: i32) {
         self.inner.set_compression_options(w_bits, level, strategy, max_dict_bytes)
     }
+
+    /// Sets compression options for blocks at the bottom-most level. Meaning of all settings is
+    /// the same as in `set_compression_options` method but affect only the bottom-most compression
+    /// which is set using `set_bottommost_compression_type` method.
+    ///
+    /// Default: `N/A`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_bottommost_compression_options(4, 5, 6, 7, true)
+    /// ```
+    pub fn set_bottommost_compression_options(&mut self, w_bits: i32, level: i32, strategy: i32, max_dict_bytes: i32, enabled: bool) {
+        self.inner.set_bottommost_compression_options(w_bits, level, strategy, max_dict_bytes, enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1054,4 +1054,16 @@ impl OptionPy {
     pub fn set_skip_stats_update_on_db_open(&mut self, skip: bool) {
         self.inner.set_skip_stats_update_on_db_open(skip)
     }
+
+    /// Specify the maximal number of info log files to be kept.
+    /// 
+    /// Default: `1000`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_keep_log_file_num(2_500)
+    /// ```
+    pub fn set_keep_log_file_num(&mut self, nfiles: usize) {
+        self.inner.set_keep_log_file_num(nfiles)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -987,4 +987,27 @@ impl OptionPy {
     pub fn set_max_compaction_bytes(&mut self, nbytes: u64) {
         self.inner.set_max_compaction_bytes(nbytes)
     }
+
+    /// Sets the WAL ttl in seconds.
+    /// 
+    /// The following two options affect how archived logs will be deleted.
+    /// 1. If both set to 0, logs will be deleted asap and will not get into the archive.
+    /// 2. If `wal_ttl_seconds` is 0 and `wal_size_limit_mb` is not 0, WAL files will be checked
+    /// every 10 min and if total size is greater then `wal_size_limit_mb`, they will be deleted
+    /// starting with the earliest until `size_limit` is met. All empty files will be deleted.
+    /// 3. If `wal_ttl_seconds` is not 0 and `wal_size_limit_mb` is 0, then WAL files will be
+    /// checked every `wal_ttl_seconds` / 2 and those that are older than `wal_ttl_seconds` will
+    /// be deleted.
+    /// 4. If both are not 0, WAL files will be checked every 10 min and both checks will be
+    /// performed with ttl being first.
+    /// 
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_wal_ttl_seconds(30)
+    /// ```
+    pub fn set_wal_ttl_seconds(&mut self, secs: u64) {
+        self.inner.set_wal_ttl_seconds(secs)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -816,4 +816,16 @@ impl OptionPy {
     pub fn set_inplace_update_support(&mut self, enabled: bool) {
         self.inner.set_inplace_update_support(enabled)
     }
+
+    /// Sets the number of locks used for inplace update.
+    /// 
+    /// Default: `10000 when inplace_update_support = true, otherwise 0.`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_inplace_update_support(20_000)
+    /// ```
+    pub fn set_inplace_update_locks(&mut self, num: usize) {
+        self.inner.set_inplace_update_locks(num)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -337,4 +337,16 @@ impl OptionPy {
     pub fn optimize_universal_style_compaction(&mut self, memtable_memory_budget: usize) {
         self.inner.optimize_universal_style_compaction(memtable_memory_budget)
     }
+
+    /// If true, any column families that didn't exist when opening the database will be created.
+    ///
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.create_missing_column_families(true)
+    /// ```
+    pub fn create_missing_column_families(&mut self, create_missing_cfs: bool) {
+        self.inner.create_missing_column_families(create_missing_cfs)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -610,4 +610,20 @@ impl OptionPy {
     pub fn set_enable_write_thread_adaptive_yield(&mut self, enabled: bool) {
         self.inner.set_enable_write_thread_adaptive_yield(enabled)
     }
+
+    /// Specifies whether an `iteration->Next()` sequentially skips over keys with the same
+    /// user-key or not.
+    /// 
+    /// This number specifies the number of keys (with the same userkey) that will be sequentially
+    /// skipped before a reseek is issued.
+    /// 
+    /// Default: `8`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_sequential_skip_in_iterations(16)
+    /// ```
+    pub fn set_max_sequential_skip_in_iterations(&mut self, num: u64) {
+        self.inner.set_max_sequential_skip_in_iterations(num)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1284,4 +1284,20 @@ impl OptionPy {
     pub fn set_allow_ingest_behind(&mut self, val: bool) {
         self.inner.set_allow_ingest_behind(val)
     }
+
+    /// If `true`, working thread may avoid doing unnecessary and long-latency operation (such as
+    /// deleting obsolete files directly or deleting memtable) and will instead schedule a
+    /// background job to do it.
+    /// 
+    /// Use it if you're latency-sensitive.
+    /// 
+    /// Default: `false (disabled)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_avoid_unnecessary_blocking_io(true)
+    /// ```
+    pub fn set_avoid_unnecessary_blocking_io(&mut self, val: bool) {
+        self.inner.set_avoid_unnecessary_blocking_io(val)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -503,4 +503,19 @@ impl OptionPy {
     pub fn set_optimize_filters_for_hits(&mut self, optimize_for_hits: bool) {
         self.inner.set_optimize_filters_for_hits(optimize_for_hits)
     }
+
+    /// Sets the periodicity when obsolete files get deleted.
+    /// 
+    /// The files that get out of scope by compaction process will still get automatically delete
+    /// on every compaction, regardless of this setting.
+    ///
+    /// Default: `6 hours`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_delete_obsolete_files_period_micros(300_000_000)
+    /// ```
+    pub fn set_delete_obsolete_files_period_micros(&mut self, micros: u64) {
+        self.inner.set_delete_obsolete_files_period_micros(micros)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -380,4 +380,19 @@ impl OptionPy {
     pub fn set_paranoid_checks(&mut self, enabled: bool) {
         self.inner.set_paranoid_checks(enabled)
     }
+
+    /// Number of threads for parallel compression. Parallel compression is enabled
+    /// only if threads > 1. **THE FEATURE IS STILL EXPERIMENTAL**
+    /// 
+    /// See [code](https://github.com/facebook/rocksdb/blob/v8.6.7/include/rocksdb/advanced_options.h#L116-L127) for more information.
+    ///
+    /// Default: `1`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_compression_options_parallel_threads(3)
+    /// ```
+    pub fn set_compression_options_parallel_threads(&mut self, num: i32) {
+        self.inner.set_compression_options_parallel_threads(num)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1134,4 +1134,19 @@ impl OptionPy {
     pub fn set_auto_tuned_ratelimiter(&mut self, rate_bytes_per_sec: i64, refill_period_us: i64, fairness: i32) {
         self.inner.set_auto_tuned_ratelimiter(rate_bytes_per_sec, refill_period_us, fairness)
     }
+
+    /// Sets the maximal size of the info log file.
+    /// 
+    /// If the log file is larger than `max_log_file_size`, a new info log file will be created.
+    /// If `max_log_file_size` is equal to zero, all logs will be written to one log file.
+    /// 
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_log_file_size(10 * 1024 * 1024)
+    /// ```
+    pub fn set_max_log_file_size(&mut self, size: usize) {
+        self.inner.set_max_log_file_size(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -660,4 +660,16 @@ impl OptionPy {
     pub fn set_use_direct_io_for_flush_and_compaction(&mut self, enabled: bool) {
         self.inner.set_use_direct_io_for_flush_and_compaction(enabled)
     }
+
+    /// Enable/disable child process inherit open files.
+    /// 
+    /// Default: `true`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_is_fd_close_on_exec(false)
+    /// ```
+    pub fn set_is_fd_close_on_exec(&mut self, enabled: bool) {
+        self.inner.set_is_fd_close_on_exec(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -943,4 +943,19 @@ impl OptionPy {
     pub fn set_advise_random_on_open(&mut self, advise: bool) {
         self.inner.set_advise_random_on_open(advise)
     }
+
+    /// Enable/disable adaptive mutex, which spins in the user space before resorting to kernel.
+    /// 
+    /// This could reduce context switch when the mutex is not heavily contended. However, if
+    /// the mutex is hot, we could end up wasting spin time.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_use_adaptive_mutex(true)
+    /// ```
+    pub fn set_use_adaptive_mutex(&mut self, enabled: bool) {
+        self.inner.set_use_adaptive_mutex(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -275,4 +275,19 @@ impl OptionPy {
     pub fn set_allow_mmap_reads(&mut self, is_enabled: bool) {
         self.inner.set_allow_mmap_reads(is_enabled)
     }
+
+    /// By default, RocksDB uses only one background thread for flush and compaction. Calling this
+    /// function will set it up such that total of total_threads is used. Good value for total_threads
+    /// is the number of cores. You almost definitely want to call this function if your system is
+    /// bottlenecked by RocksDB.
+    ///
+    /// Default: `1`
+    ///
+    /// Examples
+    /// ```
+    /// opts.increase_parallelism(3)
+    /// ```
+    pub fn increase_parallelism(&mut self, parallelism: i32) {
+        self.inner.increase_parallelism(parallelism)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -687,4 +687,20 @@ impl OptionPy {
     pub fn set_target_file_size_multiplier(&mut self, multiplier: i32) {
         self.inner.set_target_file_size_multiplier(multiplier)
     }
+
+    /// Sets the minimum number of write buffers that will be merged before writing to storage.
+    /// If set to 1, then all write buffers are flushed to L0 as individual files and this
+    /// increases read amplification because a get request has to check in all of these files.
+    /// Also, an in-memory merge may result in writing lesser data to storage if there are
+    /// duplicate records in each of these individual write buffers.
+    /// 
+    /// Default: `1`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_min_write_buffer_number(2)
+    /// ```
+    pub fn set_min_write_buffer_number(&mut self, nbuf: i32) {
+        self.inner.set_min_write_buffer_number(nbuf)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1010,4 +1010,19 @@ impl OptionPy {
     pub fn set_wal_ttl_seconds(&mut self, secs: u64) {
         self.inner.set_wal_ttl_seconds(secs)
     }
+
+    /// Sets the WAL size limit in MB.
+    /// 
+    /// If total size of WAL files is greater then `wal_size_limit_mb`, they will be deleted
+    /// starting with the earliest until `size_limit` is met.
+    /// 
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_wal_size_limit_mb(64)
+    /// ```
+    pub fn set_wal_size_limit_mb(&mut self, size: u64) {
+        self.inner.set_wal_size_limit_mb(size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -292,12 +292,12 @@ impl OptionPy {
     }
 
     /// Optimize level style compaction.
-    /// 
+    ///
     /// Default values for some parameters in `Options`` are not optimized for heavy workloads and
     /// big datasets, which means you might observe write stalls under some conditions.
-    /// 
+    ///
     /// This can be used as one of the starting points for tuning RocksDB options in such cases.
-    /// 
+    ///
     /// Internally, it sets `write_buffer_size`, `min_write_buffer_number_to_merge`,
     /// `max_write_buffer_number`, `level0_file_num_compaction_trigger`, `target_file_size_base`,
     /// `max_bytes_for_level_base`, so it can override if those parameters were set before.
@@ -383,7 +383,7 @@ impl OptionPy {
 
     /// Number of threads for parallel compression. Parallel compression is enabled
     /// only if threads > 1. **THE FEATURE IS STILL EXPERIMENTAL**
-    /// 
+    ///
     /// See [code](https://github.com/facebook/rocksdb/blob/v8.6.7/include/rocksdb/advanced_options.h#L116-L127) for more information.
     ///
     /// Default: `1`
@@ -435,7 +435,7 @@ impl OptionPy {
     /// Sets maximum size of training data passed to zstd's dictionary trainer. Using zstd's
     /// dictionary trainer can achieve even better compression ratio improvements than
     /// using `max_dict_bytes` alone.
-    /// 
+    ///
     /// The training data will be used to generate a dictionary of `max_dict_bytes`.
     ///
     /// Default: `0`
@@ -451,7 +451,7 @@ impl OptionPy {
     /// Sets maximum size of training data passed to zstd's dictionary trainer when compressing the
     /// bottom-most level. Using zstd's dictionary trainer can achieve even better compression
     /// ratio improvements than using `max_dict_bytes` alone.
-    /// 
+    ///
     /// The training data will be used to generate a dictionary of `max_dict_bytes`.
     ///
     /// Default: `0`
@@ -505,7 +505,7 @@ impl OptionPy {
     }
 
     /// Sets the periodicity when obsolete files get deleted.
-    /// 
+    ///
     /// The files that get out of scope by compaction process will still get automatically delete
     /// on every compaction, regardless of this setting.
     ///
@@ -520,7 +520,7 @@ impl OptionPy {
     }
 
     /// Prepare the DB for bulk loading.
-    /// 
+    ///
     /// All data will be in level 0 without any automatic compaction. It's recommended to manually
     /// call `CompactRange(NULL, NULL)` before reading from the database, because otherwise the
     /// read can be very slow.
@@ -551,7 +551,7 @@ impl OptionPy {
     /// Same as bytes_per_sync, but applies to WAL files.
     ///
     /// Dynamically changeable through `SetDBOptions()` API.
-    /// 
+    ///
     /// Default: `0, turned off`
     ///
     /// Examples
@@ -563,13 +563,13 @@ impl OptionPy {
     }
 
     /// Sets the maximum buffer size that is used by `WritableFileWriter`.
-    /// 
+    ///
     /// On Windows, we need to maintain an aligned buffer for writes. We allow the buffer to grow
     /// until it's size hits the limit in buffered IO and fix the buffer size when using direct IO
     /// to ensure alignment of write requests if the logical sector size is unusual
     ///
     /// Dynamically changeable through `SetDBOptions()` API.
-    /// 
+    ///
     /// Default: `1024 * 1024 (1 MB)`
     ///
     /// Examples
@@ -585,7 +585,7 @@ impl OptionPy {
     /// for SkipListFactory. Concurrent memtable writes are not compatible with
     /// inplace_update_support or filter_deletes. It is strongly recommended
     /// to set `enable_write_thread_adaptive_yield` if you are going to use this feature.
-    /// 
+    ///
     /// Default: `true`
     ///
     /// Examples
@@ -600,7 +600,7 @@ impl OptionPy {
     /// `write_thread_max_yield_usec` before blocking on a mutex. This can substantially improve
     /// throughput for concurrent workloads, regardless
     /// of whether `allow_concurrent_memtable_write` is enabled.
-    /// 
+    ///
     /// Default: `true`
     ///
     /// Examples
@@ -613,10 +613,10 @@ impl OptionPy {
 
     /// Specifies whether an `iteration->Next()` sequentially skips over keys with the same
     /// user-key or not.
-    /// 
+    ///
     /// This number specifies the number of keys (with the same userkey) that will be sequentially
     /// skipped before a reseek is issued.
-    /// 
+    ///
     /// Default: `8`
     ///
     /// Examples
@@ -629,11 +629,11 @@ impl OptionPy {
 
     /// Enable direct I/O mode for reading they may or may not improve performance depending on
     /// the use case
-    /// 
+    ///
     /// Files will be opened in "direct I/O" mode which means that data read from the disk will not
     /// be cached or buffered. The hardware buffer of the devices may however still be used.
     /// Memory mapped files are not impacted by these parameters.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -645,12 +645,12 @@ impl OptionPy {
     }
 
     /// Enable direct I/O mode for flush and compaction
-    /// 
+    ///
     /// Files will be opened in "direct I/O" mode which means that data written to the disk will
     /// not be cached or buffered. The hardware buffer of the devices may however still be used.
     /// Memory mapped files are not impacted by these parameters. they may or may not improve
     /// performance depending on the use case
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -662,7 +662,7 @@ impl OptionPy {
     }
 
     /// Enable/disable child process inherit open files.
-    /// 
+    ///
     /// Default: `true`
     ///
     /// Examples
@@ -675,9 +675,9 @@ impl OptionPy {
 
     /// By default `target_file_size_multiplier` is 1, which means by default files in different
     /// levels will have similar size.
-    /// 
+    ///
     /// Dynamically changeable through `SetOptions()` API
-    /// 
+    ///
     /// Default: `1`
     ///
     /// Examples
@@ -693,7 +693,7 @@ impl OptionPy {
     /// increases read amplification because a get request has to check in all of these files.
     /// Also, an in-memory merge may result in writing lesser data to storage if there are
     /// duplicate records in each of these individual write buffers.
-    /// 
+    ///
     /// Default: `1`
     ///
     /// Examples
@@ -705,11 +705,11 @@ impl OptionPy {
     }
 
     /// Amount of data to build up in memtables across all column families before writing to disk.
-    /// 
+    ///
     /// This is distinct from `write_buffer_size`, which enforces a limit for a single memtable.
-    /// 
+    ///
     /// This feature is disabled by default. Specify a non-zero value to enable it.
-    /// 
+    ///
     /// Default: `0 (disabled)`
     ///
     /// Examples
@@ -726,7 +726,7 @@ impl OptionPy {
     /// For example, if `max_bytes_for_level_base` is 200MB,
     /// and if `max_bytes_for_level_multiplier` is 10, total data size for level-1 will be 200MB,
     /// total file size for level-2 will be 2GB, and total file size for level-3 will be 20GB.
-    /// 
+    ///
     /// Default: `0x10000000 (256MiB).`
     ///
     /// Examples
@@ -739,7 +739,7 @@ impl OptionPy {
 
     /// The manifest file is rolled over on reaching this limit. The older manifest file be
     /// deleted. The default value is `MAX_INT` so that roll-over does not take place.
-    /// 
+    ///
     /// Default: `MAX_INT (maximum integer value for architecture, 32 or 64 bit).`
     ///
     /// Examples
@@ -752,9 +752,9 @@ impl OptionPy {
 
     /// Sets the number of files to trigger level-0 compaction. A value < 0 means that level-0
     /// compaction will not be triggered by number of files at all.
-    /// 
+    ///
     /// Dynamically changeable through `SetOptions()` API
-    /// 
+    ///
     /// Default: `4`
     ///
     /// Examples
@@ -770,9 +770,9 @@ impl OptionPy {
     /// huge pages for it to be allocated. For example: `sysctl -w vm.nr_hugepages=20` See linux
     /// doc `Documentation/vm/hugetlbpage.txt` If there isn't enough free huge page available, it
     /// will fall back to malloc.
-    /// 
+    ///
     /// Dynamically changeable through SetOptions() API
-    /// 
+    ///
     /// Default: `N/A`
     ///
     /// Examples
@@ -784,12 +784,12 @@ impl OptionPy {
     }
 
     /// Sets the maximum number of successive merge operations on a key in the memtable.
-    /// 
+    ///
     /// When a merge operation is added to the memtable and the maximum number of successive merges
     /// is reached, the value of the key will be calculated and inserted into the memtable instead
     /// of the merge operation. This will ensure that there are never
     /// more than `max_successive_merges` merge operations in the memtable.
-    /// 
+    ///
     /// Default: `0 (disabled)`
     ///
     /// Examples
@@ -801,12 +801,12 @@ impl OptionPy {
     }
 
     /// Enable/disable thread-safe inplace updates.
-    /// 
+    ///
     /// Requires updates if
     /// - key exists in current memtable
     /// - new `sizeof(new_value)` <= `sizeof(old_value)`
     /// - `old_value` for that key is a put i.e. `kTypeValue`
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -818,7 +818,7 @@ impl OptionPy {
     }
 
     /// Sets the number of locks used for inplace update.
-    /// 
+    ///
     /// Default: `10000 when inplace_update_support = true, otherwise 0.`
     ///
     /// Examples
@@ -839,18 +839,18 @@ impl OptionPy {
     /// flushed Memtables, with sizes of 32MB, 20MB, 20MB. Because trimming the next Memtable of
     /// size 20MB will reduce total memory usage to 52MB which is below the limit, RocksDB
     /// will stop trimming.
-    /// 
+    ///
     /// When using an OptimisticTransactionDB: If this value is too low, some transactions may fail
     /// at commit time due to not being able to determine whether there were any write conflicts.
-    /// 
+    ///
     /// When using a TransactionDB: If `Transaction::SetSnapshot` is used, TransactionDB will read
     /// either in-memory write buffers or SST files to do write-conflict checking. Increasing this
     /// value can reduce the number of reads to SST files done for conflict detection.
-    /// 
+    ///
     /// Setting this value to 0 will cause write buffers to be freed immediately after
     /// they are flushed. If this value is set to -1, `max_write_buffer_number * write_buffer_size`
     /// will be used.
-    /// 
+    ///
     /// Default: `If using a TransactionDB/OptimisticTransactionDB, the default value will be set to the value of 'max_write_buffer_number * write_buffer_size' if it is not explicitly set by the user. Otherwise, the default is 0.`
     ///
     /// Examples
@@ -864,13 +864,13 @@ impl OptionPy {
     /// By default, a single write thread queue is maintained. The thread gets to the head of the
     /// queue becomes write batch group leader and responsible for writing to WAL and memtable for
     /// the batch group.
-    /// 
+    ///
     /// If `enable_pipelined_write` is true, separate write thread queue is maintained for WAL
     /// write and memtable write. A write thread first enter WAL writer queue and then memtable
     /// writer queue. Pending thread on the WAL writer queue thus only have to wait for previous
     /// writers to finish their WAL writing but not the memtable writing. Enabling the feature may
     /// improve write throughput and reduce latency of the prepare phase of two-phase commit.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -882,7 +882,7 @@ impl OptionPy {
     }
 
     /// Measure IO stats in compactions and flushes, if `true`.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -896,7 +896,7 @@ impl OptionPy {
     /// Once write-ahead logs exceed this size, we will start forcing the flush of column families
     /// whose memtables are backed by the oldest live WAL file (i.e. the ones that are causing all
     /// the space amplification).
-    /// 
+    ///
     /// Default: `0`
     ///
     /// Examples
@@ -908,7 +908,7 @@ impl OptionPy {
     }
 
     /// If not zero, dump `rocksdb.stats` to LOG every `stats_dump_period_sec`.
-    /// 
+    ///
     /// Default: `600 (10 mins)`
     ///
     /// Examples
@@ -920,7 +920,7 @@ impl OptionPy {
     }
 
     /// If not zero, dump `rocksdb.stats` to RocksDB to LOG every `stats_persist_period_sec`.
-    /// 
+    ///
     /// Default: `600 (10 mins)`
     ///
     /// Examples
@@ -933,7 +933,7 @@ impl OptionPy {
 
     /// When set to `true`, reading SST files will opt out of the filesystem's readahead.
     /// Setting this to false may improve sequential iteration performance.
-    /// 
+    ///
     /// Default: `true`
     ///
     /// Examples
@@ -945,10 +945,10 @@ impl OptionPy {
     }
 
     /// Enable/disable adaptive mutex, which spins in the user space before resorting to kernel.
-    /// 
+    ///
     /// This could reduce context switch when the mutex is not heavily contended. However, if
     /// the mutex is hot, we could end up wasting spin time.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -962,7 +962,7 @@ impl OptionPy {
     /// When a prefix_extractor is defined through `opts.set_prefix_extractor` this creates a
     /// prefix bloom filter for each memtable with the size of
     /// `write_buffer_size * memtable_prefix_bloom_ratio` (capped at 0.25).
-    /// 
+    ///
     /// Default: `0`
     ///
     /// Examples
@@ -975,9 +975,9 @@ impl OptionPy {
 
     /// Sets the maximum number of bytes in all compacted files. We try to limit number of bytes in
     /// one compaction to be lower than this threshold. But it's not guaranteed.
-    /// 
+    ///
     /// Value 0 will be sanitized.
-    /// 
+    ///
     /// Default: `target_file_size_base * 25`
     ///
     /// Examples
@@ -989,7 +989,7 @@ impl OptionPy {
     }
 
     /// Sets the WAL ttl in seconds.
-    /// 
+    ///
     /// The following two options affect how archived logs will be deleted.
     /// 1. If both set to 0, logs will be deleted asap and will not get into the archive.
     /// 2. If `wal_ttl_seconds` is 0 and `wal_size_limit_mb` is not 0, WAL files will be checked
@@ -1000,7 +1000,7 @@ impl OptionPy {
     /// be deleted.
     /// 4. If both are not 0, WAL files will be checked every 10 min and both checks will be
     /// performed with ttl being first.
-    /// 
+    ///
     /// Default: `0`
     ///
     /// Examples
@@ -1012,10 +1012,10 @@ impl OptionPy {
     }
 
     /// Sets the WAL size limit in MB.
-    /// 
+    ///
     /// If total size of WAL files is greater then `wal_size_limit_mb`, they will be deleted
     /// starting with the earliest until `size_limit` is met.
-    /// 
+    ///
     /// Default: `0`
     ///
     /// Examples
@@ -1027,10 +1027,10 @@ impl OptionPy {
     }
 
     /// Sets the number of bytes to preallocate (via fallocate) the manifest files.
-    /// 
+    ///
     /// Default is 4MB, which is reasonable to reduce random IO as well as prevent overallocation
     /// for mounts that preallocate large amounts of data (such as xfs's allocsize option).
-    /// 
+    ///
     /// Default: `4MB`
     ///
     /// Examples
@@ -1044,7 +1044,7 @@ impl OptionPy {
     /// If true, then `DB::Open()` will not update the statistics used to optimize compaction
     /// decision by loading table properties from many files. Turning off this feature will
     /// improve DBOpen time especially in disk environment.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -1056,7 +1056,7 @@ impl OptionPy {
     }
 
     /// Specify the maximal number of info log files to be kept.
-    /// 
+    ///
     /// Default: `1000`
     ///
     /// Examples
@@ -1068,7 +1068,7 @@ impl OptionPy {
     }
 
     /// Allow the OS to mmap file for writing.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -1081,7 +1081,7 @@ impl OptionPy {
 
     /// If enabled, WAL is not flushed automatically after each write. Instead it relies on manual
     /// invocation of `DB::flush_wal()` to write the WAL buffer to its file.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -1095,10 +1095,10 @@ impl OptionPy {
     /// Guarantee that all column families are flushed together atomically. This option applies to
     /// both manual flushes (`db.flush()`) and automatic background flushes caused when memtables
     /// are filled.
-    /// 
+    ///
     /// Note that this is only useful when the WAL is disabled. When using the WAL, writes are
     /// always consistent across column families.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -1111,7 +1111,7 @@ impl OptionPy {
 
     /// Use to control write rate of flush and compaction. Flush has higher priority than
     /// compaction. If rate limiter is enabled, `bytes_per_sync` is set to 1MB by default.
-    /// 
+    ///
     /// Default: `disable`
     ///
     /// Examples
@@ -1124,7 +1124,7 @@ impl OptionPy {
 
     /// Use to control write rate of flush and compaction. Flush has higher priority than
     /// compaction. If rate limiter is enabled, `bytes_per_sync` is set to 1MB by default.
-    /// 
+    ///
     /// Default: `disable`
     ///
     /// Examples
@@ -1136,10 +1136,10 @@ impl OptionPy {
     }
 
     /// Sets the maximal size of the info log file.
-    /// 
+    ///
     /// If the log file is larger than `max_log_file_size`, a new info log file will be created.
     /// If `max_log_file_size` is equal to zero, all logs will be written to one log file.
-    /// 
+    ///
     /// Default: `0`
     ///
     /// Examples
@@ -1151,10 +1151,10 @@ impl OptionPy {
     }
 
     /// Sets the time for the info log file to roll (in seconds).
-    /// 
+    ///
     /// If specified with non-zero value, log file will be rolled if it has been active longer
     /// than `log_file_time_to_roll`.
-    /// 
+    ///
     /// Default: `0 (disabled)`
     ///
     /// Examples
@@ -1166,12 +1166,12 @@ impl OptionPy {
     }
 
     /// Controls the recycling of log files.
-    /// 
+    ///
     /// If non-zero, previously written log files will be reused for new logs, overwriting the old
     /// data. The value indicates how many such files we will keep around at any point in time for
     /// later use. This is more efficient because the blocks are already allocated and fdatasync
     /// does not need to update the inode after each write.
-    /// 
+    ///
     /// Default: `0`
     ///
     /// Examples
@@ -1184,7 +1184,7 @@ impl OptionPy {
 
     /// Sets the threshold at which all writes will be slowed down to at least `delayed_write_rate`
     /// if estimated bytes needed to be compaction exceed this threshold.
-    /// 
+    ///
     /// Default: `64GB`
     ///
     /// Examples
@@ -1197,7 +1197,7 @@ impl OptionPy {
 
     /// Sets the bytes threshold at which all writes are stopped if estimated bytes needed to be
     /// compaction exceed this threshold.
-    /// 
+    ///
     /// Default: `256GB`
     ///
     /// Examples
@@ -1209,9 +1209,9 @@ impl OptionPy {
     }
 
     /// Sets the size of one block in arena memory allocation.
-    /// 
+    ///
     /// If <= 0, a proper value is automatically calculated (usually 1/10 of `writer_buffer_size`).
-    /// 
+    ///
     /// Default: `0`
     ///
     /// Examples
@@ -1223,7 +1223,7 @@ impl OptionPy {
     }
 
     /// If `true`, then print malloc stats together with `rocksdb.stats` when printing to LOG.
-    /// 
+    ///
     /// Default: `false`
     ///
     /// Examples
@@ -1237,9 +1237,9 @@ impl OptionPy {
     /// Enable whole key bloom filter in memtable. Note this will only take effect if
     /// `memtable_prefix_bloom_size_ratio` is not 0. Enabling whole key filtering can potentially
     /// reduce CPU usage for point-look-ups.
-    /// 
+    ///
     /// Dynamically changeable through `SetOptions()` API
-    /// 
+    ///
     /// Default: `false (disable)`
     ///
     /// Examples
@@ -1251,11 +1251,11 @@ impl OptionPy {
     }
 
     /// Enable the use of key-value separation.
-    /// 
+    ///
     /// More details can be found here: [Integrated BlobDB](https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html).
-    /// 
+    ///
     /// Dynamically changeable through `SetOptions()` API
-    /// 
+    ///
     /// Default: `false (disable)`
     ///
     /// Examples
@@ -1269,14 +1269,14 @@ impl OptionPy {
     /// Set this option to true during creation of database if you want to be able to ingest behind
     /// (call `IngestExternalFile()` skipping keys that already exist, rather than overwriting
     /// matching keys). Setting this option to true has the following effects:
-    /// 
+    ///
     /// 1. Disable some internal optimizations around SST file compression.
     /// 2. Reserve the last level for ingested files only.
     /// 3. Compaction will not include any file from the last level.
-    /// 
+    ///
     /// Note that only Universal Compaction supports `allow_ingest_behind`.
     /// `num_levels` should be >= 3 if this option is turned on.
-    /// 
+    ///
     /// Default: `false Immutable`
     ///
     /// Examples
@@ -1290,9 +1290,9 @@ impl OptionPy {
     /// If `true`, working thread may avoid doing unnecessary and long-latency operation (such as
     /// deleting obsolete files directly or deleting memtable) and will instead schedule a
     /// background job to do it.
-    /// 
+    ///
     /// Use it if you're latency-sensitive.
-    /// 
+    ///
     /// Default: `false (disabled)`
     ///
     /// Examples
@@ -1306,16 +1306,16 @@ impl OptionPy {
     /// If true, the log numbers and sizes of the synced WALs are tracked in MANIFEST. During DB
     /// recovery, if a synced WAL is missing from disk, or the WAL's size does not match the
     /// recorded size in MANIFEST, an error will be reported and the recovery will be aborted.
-    /// 
+    ///
     /// This is one additional protection against WAL corruption besides
     /// the per-WAL-entry checksum.
-    /// 
+    ///
     /// Note that this option does not work with secondary instance. Currently, only syncing closed
     /// WALs are tracked. Calling `DB::SyncWAL()`, etc. or writing with `WriteOptions::sync=true`
     /// to sync the live WAL is not tracked for performance/efficiency reasons.
-    /// 
+    ///
     /// See: https://github.com/facebook/rocksdb/wiki/Track-WAL-in-MANIFEST
-    /// 
+    ///
     /// Default: `false (disabled)`
     ///
     /// Examples
@@ -1327,7 +1327,7 @@ impl OptionPy {
     }
 
     /// Returns the value of the `track_and_verify_wals_in_manifest` option.
-    /// 
+    ///
     /// Examples
     /// ```
     /// opts.get_track_and_verify_wals_in_manifest()
@@ -1342,9 +1342,9 @@ impl OptionPy {
     /// 1. The IDENTITY file is not checksummed, so it is not as safe against corruption.
     /// 2. The IDENTITY file may or may not be copied with the DB
     /// (e.g. not copied by `BackupEngine`), so is not reliable for the provenance of a DB.
-    /// 
+    ///
     /// This option might eventually be obsolete and removed as Identity files are phased out.
-    /// 
+    ///
     /// Default: `true (enabled)`
     ///
     /// Examples
@@ -1356,7 +1356,7 @@ impl OptionPy {
     }
 
     /// Returns the value of the `write_dbid_to_manifest` option.
-    /// 
+    ///
     /// Examples
     /// ```
     /// opts.get_write_dbid_to_manifest()

--- a/src/option.rs
+++ b/src/option.rs
@@ -463,4 +463,18 @@ impl OptionPy {
     pub fn set_bottommost_zstd_max_train_bytes(&mut self, value: i32, enabled: bool) {
         self.inner.set_bottommost_zstd_max_train_bytes(value, enabled)
     }
+
+    /// If non-zero, we perform bigger reads when doing compaction. If you're running RocksDB on
+    /// spinning disks, you should set this to at least 2MB. That way RocksDB's compaction is doing
+    /// sequential instead of random reads.
+    ///
+    /// Default: `2 * 1024 * 1024 (2MB)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_compaction_readahead_size(16 * 1024 * 1024)
+    /// ```
+    pub fn set_compaction_readahead_size(&mut self, compaction_readahead_size: usize) {
+        self.inner.set_compaction_readahead_size(compaction_readahead_size)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1276,6 +1276,8 @@ impl OptionPy {
     /// 
     /// Note that only Universal Compaction supports `allow_ingest_behind`.
     /// `num_levels` should be >= 3 if this option is turned on.
+    /// 
+    /// Default: `false Immutable`
     ///
     /// Examples
     /// ```

--- a/src/option.rs
+++ b/src/option.rs
@@ -579,4 +579,20 @@ impl OptionPy {
     pub fn set_writable_file_max_buffer_size(&mut self, nbytes: u64) {
         self.inner.set_writable_file_max_buffer_size(nbytes)
     }
+
+    /// If true, allow multi-writers to update mem tables in parallel.
+    /// Only some memtable_factory-s support concurrent writes; currently it is implemented only
+    /// for SkipListFactory. Concurrent memtable writes are not compatible with
+    /// inplace_update_support or filter_deletes. It is strongly recommended
+    /// to set `enable_write_thread_adaptive_yield` if you are going to use this feature.
+    /// 
+    /// Default: `true`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_allow_concurrent_memtable_write(false)
+    /// ```
+    pub fn set_allow_concurrent_memtable_write(&mut self, allow: bool) {
+        self.inner.set_allow_concurrent_memtable_write(allow)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -447,4 +447,20 @@ impl OptionPy {
     pub fn set_zstd_max_train_bytes(&mut self, value: i32) {
         self.inner.set_zstd_max_train_bytes(value)
     }
+
+    /// Sets maximum size of training data passed to zstd's dictionary trainer when compressing the
+    /// bottom-most level. Using zstd's dictionary trainer can achieve even better compression
+    /// ratio improvements than using `max_dict_bytes` alone.
+    /// 
+    /// The training data will be used to generate a dictionary of `max_dict_bytes`.
+    ///
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_zstd_max_train_bytes(64 * 1024 * 1024, true)
+    /// ```
+    pub fn set_bottommost_zstd_max_train_bytes(&mut self, value: i32, enabled: bool) {
+        self.inner.set_bottommost_zstd_max_train_bytes(value, enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -860,4 +860,24 @@ impl OptionPy {
     pub fn set_max_write_buffer_size_to_maintain(&mut self, size: i64) {
         self.inner.set_max_write_buffer_size_to_maintain(size)
     }
+
+    /// By default, a single write thread queue is maintained. The thread gets to the head of the
+    /// queue becomes write batch group leader and responsible for writing to WAL and memtable for
+    /// the batch group.
+    /// 
+    /// If `enable_pipelined_write` is true, separate write thread queue is maintained for WAL
+    /// write and memtable write. A write thread first enter WAL writer queue and then memtable
+    /// writer queue. Pending thread on the WAL writer queue thus only have to wait for previous
+    /// writers to finish their WAL writing but not the memtable writing. Enabling the feature may
+    /// improve write throughput and reduce latency of the prepare phase of two-phase commit.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_enable_pipelined_write(true)
+    /// ```
+    pub fn set_enable_pipelined_write(&mut self, value: bool) {
+        self.inner.set_enable_pipelined_write(value)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -561,4 +561,22 @@ impl OptionPy {
     pub fn set_wal_bytes_per_sync(&mut self, nbytes: u64) {
         self.inner.set_wal_bytes_per_sync(nbytes)
     }
+
+    /// Sets the maximum buffer size that is used by `WritableFileWriter`.
+    /// 
+    /// On Windows, we need to maintain an aligned buffer for writes. We allow the buffer to grow
+    /// until it's size hits the limit in buffered IO and fix the buffer size when using direct IO
+    /// to ensure alignment of write requests if the logical sector size is unusual
+    ///
+    /// Dynamically changeable through `SetDBOptions()` API.
+    /// 
+    /// Default: `1024 * 1024 (1 MB)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_writable_file_max_buffer_size(4096 * 1024)
+    /// ```
+    pub fn set_writable_file_max_buffer_size(&mut self, nbytes: u64) {
+        self.inner.set_writable_file_max_buffer_size(nbytes)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -918,4 +918,16 @@ impl OptionPy {
     pub fn set_stats_dump_period_sec(&mut self, period: u32) {
         self.inner.set_stats_dump_period_sec(period)
     }
+
+    /// If not zero, dump `rocksdb.stats` to RocksDB to LOG every `stats_persist_period_sec`.
+    /// 
+    /// Default: `600 (10 mins)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_stats_persist_period_sec(5)
+    /// ```
+    pub fn set_stats_persist_period_sec(&mut self, period: u32) {
+        self.inner.set_stats_persist_period_sec(period)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1335,4 +1335,23 @@ impl OptionPy {
     pub fn get_track_and_verify_wals_in_manifest(&self) -> bool {
         return self.inner.get_track_and_verify_wals_in_manifest()
     }
+
+    /// The DB unique ID can be saved in the DB manifest (preferred, this option) or an IDENTITY
+    /// file (historical, deprecated), or both. If this option is set to false (old behavior),
+    /// then `write_identity_file` must be set to true. The manifest is preferred because
+    /// 1. The IDENTITY file is not checksummed, so it is not as safe against corruption.
+    /// 2. The IDENTITY file may or may not be copied with the DB
+    /// (e.g. not copied by `BackupEngine`), so is not reliable for the provenance of a DB.
+    /// 
+    /// This option might eventually be obsolete and removed as Identity files are phased out.
+    /// 
+    /// Default: `true (enabled)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_write_dbid_to_manifest(false)
+    /// ```
+    pub fn set_write_dbid_to_manifest(&mut self, val: bool) {
+        self.inner.set_write_dbid_to_manifest(val)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -477,4 +477,18 @@ impl OptionPy {
     pub fn set_compaction_readahead_size(&mut self, compaction_readahead_size: usize) {
         self.inner.set_compaction_readahead_size(compaction_readahead_size)
     }
+
+    /// Allow RocksDB to pick dynamic base of bytes for levels. With this feature turned on,
+    /// RocksDB will automatically adjust max bytes for each level. The goal of this feature is to
+    /// have lower bound on size amplification.
+    ///
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_level_compaction_dynamic_level_bytes(true)
+    /// ```
+    pub fn set_level_compaction_dynamic_level_bytes(&mut self, enabled: bool) {
+        self.inner.set_level_compaction_dynamic_level_bytes(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -313,4 +313,28 @@ impl OptionPy {
     pub fn optimize_level_style_compaction(&mut self, memtable_memory_budget: usize) {
         self.inner.optimize_level_style_compaction(memtable_memory_budget)
     }
+
+    /// Optimize universal style compaction.
+    ///
+    /// Default values for some parameters in Options are not optimized for heavy workloads and big
+    /// datasets, which means you might observe write stalls under some conditions.
+    ///
+    /// This can be used as one of the starting points for tuning RocksDB options in such cases.
+    ///
+    /// Internally, it sets `write_buffer_size`, `min_write_buffer_number_to_merge`,
+    /// `max_write_buffer_number`, `level0_file_num_compaction_trigger`, `target_file_size_base`,
+    /// `max_bytes_for_level_base`, so it can override if those parameters were set before.
+    ///
+    /// It sets buffer sizes so that memory consumption would be
+    /// constrained by `memtable_memory_budget`.
+    ///
+    /// Default: `0x4000000`
+    ///
+    /// Examples
+    /// ```
+    /// opts.optimize_universal_style_compaction(64 * 1024 * 1024)
+    /// ```
+    pub fn optimize_universal_style_compaction(&mut self, memtable_memory_budget: usize) {
+        self.inner.optimize_universal_style_compaction(memtable_memory_budget)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1091,4 +1091,21 @@ impl OptionPy {
     pub fn set_manual_wal_flush(&mut self, is_enabled: bool) {
         self.inner.set_manual_wal_flush(is_enabled)
     }
+
+    /// Guarantee that all column families are flushed together atomically. This option applies to
+    /// both manual flushes (`db.flush()`) and automatic background flushes caused when memtables
+    /// are filled.
+    /// 
+    /// Note that this is only useful when the WAL is disabled. When using the WAL, writes are
+    /// always consistent across column families.
+    /// 
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_atomic_flush(true)
+    /// ```
+    pub fn set_atomic_flush(&mut self, atomic_flush: bool) {
+        self.inner.set_atomic_flush(atomic_flush)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1164,4 +1164,21 @@ impl OptionPy {
     pub fn set_log_file_time_to_roll(&mut self, secs: usize) {
         self.inner.set_log_file_time_to_roll(secs)
     }
+
+    /// Controls the recycling of log files.
+    /// 
+    /// If non-zero, previously written log files will be reused for new logs, overwriting the old
+    /// data. The value indicates how many such files we will keep around at any point in time for
+    /// later use. This is more efficient because the blocks are already allocated and fdatasync
+    /// does not need to update the inode after each write.
+    /// 
+    /// Default: `0`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_recycle_log_file_num(3)
+    /// ```
+    pub fn set_recycle_log_file_num(&mut self, num: usize) {
+        self.inner.set_recycle_log_file_num(num)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -361,4 +361,23 @@ impl OptionPy {
     pub fn set_error_if_exists(&mut self, enabled: bool) {
         self.inner.set_error_if_exists(enabled)
     }
+
+    /// Enable/disable paranoid checks.
+    ///
+    /// If true, the implementation will do aggressive checking of the data it is processing and
+    /// will stop early if it detects any errors. This may have unforeseen ramifications: for
+    /// example, a corruption of one DB entry may cause a large number of entries to become
+    /// unreadable or for the entire DB to become unopenable. If any of the writes to the database
+    /// fails (Put, Delete, Merge, Write), the database will switch to read-only mode and fail all
+    /// other Write operations.
+    ///
+    /// Default: `false`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_paranoid_checks(true)
+    /// ```
+    pub fn set_paranoid_checks(&mut self, enabled: bool) {
+        self.inner.set_paranoid_checks(enabled)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -782,4 +782,21 @@ impl OptionPy {
     pub fn set_memtable_huge_page_size(&mut self, size: usize) {
         self.inner.set_memtable_huge_page_size(size)
     }
+
+    /// Sets the maximum number of successive merge operations on a key in the memtable.
+    /// 
+    /// When a merge operation is added to the memtable and the maximum number of successive merges
+    /// is reached, the value of the key will be calculated and inserted into the memtable instead
+    /// of the merge operation. This will ensure that there are never
+    /// more than `max_successive_merges` merge operations in the memtable.
+    /// 
+    /// Default: `0 (disabled)`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_successive_merges(8)
+    /// ```
+    pub fn set_max_successive_merges(&mut self, num: usize) {
+        self.inner.set_max_successive_merges(num)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -972,4 +972,19 @@ impl OptionPy {
     pub fn set_memtable_prefix_bloom_ratio(&mut self, ratio: f64) {
         self.inner.set_memtable_prefix_bloom_ratio(ratio)
     }
+
+    /// Sets the maximum number of bytes in all compacted files. We try to limit number of bytes in
+    /// one compaction to be lower than this threshold. But it's not guaranteed.
+    /// 
+    /// Value 0 will be sanitized.
+    /// 
+    /// Default: `target_file_size_base * 25`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_max_compaction_bytes(0)
+    /// ```
+    pub fn set_max_compaction_bytes(&mut self, nbytes: u64) {
+        self.inner.set_max_compaction_bytes(nbytes)
+    }
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -1025,4 +1025,19 @@ impl OptionPy {
     pub fn set_wal_size_limit_mb(&mut self, size: u64) {
         self.inner.set_wal_size_limit_mb(size)
     }
+
+    /// Sets the number of bytes to preallocate (via fallocate) the manifest files.
+    /// 
+    /// Default is 4MB, which is reasonable to reduce random IO as well as prevent overallocation
+    /// for mounts that preallocate large amounts of data (such as xfs's allocsize option).
+    /// 
+    /// Default: `4MB`
+    ///
+    /// Examples
+    /// ```
+    /// opts.set_manifest_preallocation_size(8 * 1024 * 1024)
+    /// ```
+    pub fn set_manifest_preallocation_size(&mut self, size: usize) {
+        self.inner.set_manifest_preallocation_size(size)
+    }
 }

--- a/test/option.py
+++ b/test/option.py
@@ -467,3 +467,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_dump_malloc_stats(True))
         self.assertRaises(TypeError, o.set_dump_malloc_stats, None)
+
+    def test_set_memtable_whole_key_filtering(self):
+        o = Option()
+
+        self.assertIsNone(o.set_memtable_whole_key_filtering(True))
+        self.assertRaises(TypeError, o.set_memtable_whole_key_filtering, None)

--- a/test/option.py
+++ b/test/option.py
@@ -461,3 +461,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_arena_block_size(32 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_arena_block_size, None)
+
+    def test_set_dump_malloc_stats(self):
+        o = Option()
+
+        self.assertIsNone(o.set_dump_malloc_stats(True))
+        self.assertRaises(TypeError, o.set_dump_malloc_stats, None)

--- a/test/option.py
+++ b/test/option.py
@@ -197,3 +197,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_max_file_opening_threads(32))
         self.assertRaises(TypeError, o.set_max_file_opening_threads, None)
+
+    def test_set_wal_bytes_per_sync(self):
+        o = Option()
+
+        self.assertIsNone(o.set_wal_bytes_per_sync(1 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_wal_bytes_per_sync, None)

--- a/test/option.py
+++ b/test/option.py
@@ -335,3 +335,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_stats_dump_period_sec(300))
         self.assertRaises(TypeError, o.set_stats_dump_period_sec, None)
+
+    def test_stats_persist_period_sec(self):
+        o = Option()
+
+        self.assertIsNone(o.set_stats_persist_period_sec(5))
+        self.assertRaises(TypeError, o.set_stats_persist_period_sec, None)

--- a/test/option.py
+++ b/test/option.py
@@ -329,3 +329,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_max_total_wal_size(1 << 30))
         self.assertRaises(TypeError, o.set_max_total_wal_size, None)
+
+    def test_set_stats_dump_period_sec(self):
+        o = Option()
+
+        self.assertIsNone(o.set_stats_dump_period_sec(300))
+        self.assertRaises(TypeError, o.set_stats_dump_period_sec, None)

--- a/test/option.py
+++ b/test/option.py
@@ -491,3 +491,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_avoid_unnecessary_blocking_io(True))
         self.assertRaises(TypeError, o.set_avoid_unnecessary_blocking_io, None)
+
+    def test_set_track_and_verify_wals_in_manifest(self):
+        o = Option()
+
+        self.assertIsNone(o.set_track_and_verify_wals_in_manifest(True))
+        self.assertRaises(TypeError, o.set_track_and_verify_wals_in_manifest, None)

--- a/test/option.py
+++ b/test/option.py
@@ -239,3 +239,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_use_direct_io_for_flush_and_compaction(True))
         self.assertRaises(TypeError, o.set_use_direct_io_for_flush_and_compaction, None)
+
+    def test_set_is_fd_close_on_exec(self):
+        o = Option()
+
+        self.assertIsNone(o.set_is_fd_close_on_exec(False))
+        self.assertRaises(TypeError, o.set_is_fd_close_on_exec, None)

--- a/test/option.py
+++ b/test/option.py
@@ -299,3 +299,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_inplace_update_support(True))
         self.assertRaises(TypeError, o.set_inplace_update_support, None)
+
+    def test_set_inplace_update_locks(self):
+        o = Option()
+
+        self.assertIsNone(o.set_inplace_update_locks(25_000))
+        self.assertRaises(TypeError, o.set_inplace_update_locks, None)

--- a/test/option.py
+++ b/test/option.py
@@ -191,3 +191,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.prepare_for_bulk_load())
         self.assertRaises(TypeError, o.prepare_for_bulk_load, None)
+
+    def test_set_max_file_opening_threads(self):
+        o = Option()
+
+        self.assertIsNone(o.set_max_file_opening_threads(32))
+        self.assertRaises(TypeError, o.set_max_file_opening_threads, None)

--- a/test/option.py
+++ b/test/option.py
@@ -449,3 +449,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_soft_pending_compaction_bytes_limit(96 * 1024 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_soft_pending_compaction_bytes_limit, None)
+
+    def test_set_hard_pending_compaction_bytes_limit(self):
+        o = Option()
+
+        self.assertIsNone(o.set_hard_pending_compaction_bytes_limit(512 * 1024 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_hard_pending_compaction_bytes_limit, None)

--- a/test/option.py
+++ b/test/option.py
@@ -485,3 +485,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_allow_ingest_behind(True))
         self.assertRaises(TypeError, o.set_allow_ingest_behind, None)
+
+    def test_set_avoid_unnecessary_blocking_io(self):
+        o = Option()
+
+        self.assertIsNone(o.set_avoid_unnecessary_blocking_io(True))
+        self.assertRaises(TypeError, o.set_avoid_unnecessary_blocking_io, None)

--- a/test/option.py
+++ b/test/option.py
@@ -336,7 +336,7 @@ class TestOption(unittest.TestCase):
         self.assertIsNone(o.set_stats_dump_period_sec(300))
         self.assertRaises(TypeError, o.set_stats_dump_period_sec, None)
 
-    def test_stats_persist_period_sec(self):
+    def test_set_stats_persist_period_sec(self):
         o = Option()
 
         self.assertIsNone(o.set_stats_persist_period_sec(5))

--- a/test/option.py
+++ b/test/option.py
@@ -233,3 +233,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_use_direct_reads(True))
         self.assertRaises(TypeError, o.set_use_direct_reads, None)
+
+    def test_set_use_direct_io_for_flush_and_compaction(self):
+        o = Option()
+
+        self.assertIsNone(o.set_use_direct_io_for_flush_and_compaction(True))
+        self.assertRaises(TypeError, o.set_use_direct_io_for_flush_and_compaction, None)

--- a/test/option.py
+++ b/test/option.py
@@ -377,3 +377,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_wal_size_limit_mb(64))
         self.assertRaises(TypeError, o.set_wal_size_limit_mb, None)
+
+    def test_set_manifest_preallocation_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_manifest_preallocation_size(8 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_manifest_preallocation_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -173,3 +173,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_level_compaction_dynamic_level_bytes(True))
         self.assertRaises(TypeError, o.set_level_compaction_dynamic_level_bytes, None)
+
+    def test_set_optimize_filters_for_hits(self):
+        o = Option()
+
+        self.assertIsNone(o.set_optimize_filters_for_hits(True))
+        self.assertRaises(TypeError, o.set_optimize_filters_for_hits, None)

--- a/test/option.py
+++ b/test/option.py
@@ -281,3 +281,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_level_zero_file_num_compaction_trigger(8))
         self.assertRaises(TypeError, o.set_level_zero_file_num_compaction_trigger, None)
+
+    def test_set_memtable_huge_page_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_memtable_huge_page_size(20))
+        self.assertRaises(TypeError, o.set_memtable_huge_page_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -131,3 +131,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_paranoid_checks(True))
         self.assertRaises(TypeError, o.set_paranoid_checks, None)
+
+    def test_set_compression_options_parallel_threads(self):
+        o = Option()
+
+        self.assertIsNone(o.set_compression_options_parallel_threads(3))
+        self.assertRaises(TypeError, o.set_compression_options_parallel_threads, None)

--- a/test/option.py
+++ b/test/option.py
@@ -167,3 +167,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_compaction_readahead_size(16 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_compaction_readahead_size, None)
+
+    def test_set_level_compaction_dynamic_level_bytes(self):
+        o = Option()
+
+        self.assertIsNone(o.set_level_compaction_dynamic_level_bytes(True))
+        self.assertRaises(TypeError, o.set_level_compaction_dynamic_level_bytes, None)

--- a/test/option.py
+++ b/test/option.py
@@ -101,3 +101,9 @@ class TestOption(unittest.TestCase):
         self.assertIsNone(o.increase_parallelism(2))
         self.assertRaises(TypeError, o.increase_parallelism, 1.1)
         self.assertRaises(TypeError, o.increase_parallelism, None)
+
+    def test_optimize_level_style_compaction(self):
+        o = Option()
+
+        self.assertIsNone(o.optimize_level_style_compaction(0x40000))
+        self.assertRaises(TypeError, o.optimize_level_style_compaction, 1.024)

--- a/test/option.py
+++ b/test/option.py
@@ -185,3 +185,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_delete_obsolete_files_period_micros(300_000_000))
         self.assertRaises(TypeError, o.set_delete_obsolete_files_period_micros, None)
+
+    def test_prepare_for_bulk_load(self):
+        o = Option()
+
+        self.assertIsNone(o.prepare_for_bulk_load())
+        self.assertRaises(TypeError, o.prepare_for_bulk_load, None)

--- a/test/option.py
+++ b/test/option.py
@@ -257,3 +257,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_min_write_buffer_number(2))
         self.assertRaises(TypeError, o.set_min_write_buffer_number, None)
+
+    def test_set_db_write_buffer_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_db_write_buffer_size(128 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_db_write_buffer_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -113,3 +113,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.optimize_universal_style_compaction(0x40000))
         self.assertRaises(TypeError, o.optimize_universal_style_compaction, 1.024)
+
+    def test_create_missing_column_families(self):
+        o = Option()
+
+        self.assertIsNone(o.create_missing_column_families(True))
+        self.assertRaises(TypeError, o.create_missing_column_families, None)

--- a/test/option.py
+++ b/test/option.py
@@ -317,3 +317,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_enable_pipelined_write(True))
         self.assertRaises(TypeError, o.set_enable_pipelined_write, None)
+
+    def test_set_report_bg_io_stats(self):
+        o = Option()
+
+        self.assertIsNone(o.set_report_bg_io_stats(True))
+        self.assertRaises(TypeError, o.set_report_bg_io_stats, None)

--- a/test/option.py
+++ b/test/option.py
@@ -275,3 +275,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_max_manifest_file_size(20 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_max_manifest_file_size, None)
+
+    def test_set_level_zero_file_num_compaction_trigger(self):
+        o = Option()
+
+        self.assertIsNone(o.set_level_zero_file_num_compaction_trigger(8))
+        self.assertRaises(TypeError, o.set_level_zero_file_num_compaction_trigger, None)

--- a/test/option.py
+++ b/test/option.py
@@ -365,3 +365,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_max_compaction_bytes(0))
         self.assertRaises(TypeError, o.set_max_compaction_bytes, None)
+
+    def test_set_wal_ttl_seconds(self):
+        o = Option()
+
+        self.assertIsNone(o.set_wal_ttl_seconds(30))
+        self.assertRaises(TypeError, o.set_wal_ttl_seconds, None)

--- a/test/option.py
+++ b/test/option.py
@@ -359,3 +359,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_memtable_prefix_bloom_ratio(0.2))
         self.assertRaises(TypeError, o.set_memtable_prefix_bloom_ratio, None)
+
+    def test_set_max_compaction_bytes(self):
+        o = Option()
+
+        self.assertIsNone(o.set_max_compaction_bytes(0))
+        self.assertRaises(TypeError, o.set_max_compaction_bytes, None)

--- a/test/option.py
+++ b/test/option.py
@@ -311,3 +311,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_max_write_buffer_size_to_maintain(20_000))
         self.assertRaises(TypeError, o.set_max_write_buffer_size_to_maintain, None)
+
+    def test_set_enable_pipelined_write(self):
+        o = Option()
+
+        self.assertIsNone(o.set_enable_pipelined_write(True))
+        self.assertRaises(TypeError, o.set_enable_pipelined_write, None)

--- a/test/option.py
+++ b/test/option.py
@@ -137,3 +137,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_compression_options_parallel_threads(3))
         self.assertRaises(TypeError, o.set_compression_options_parallel_threads, None)
+
+    def test_set_compression_options(self):
+        o = Option()
+
+        self.assertIsNone(o.set_compression_options(4, 5, 6, 7))
+        self.assertRaises(TypeError, o.set_compression_options, None, None, None, None)

--- a/test/option.py
+++ b/test/option.py
@@ -371,3 +371,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_wal_ttl_seconds(30))
         self.assertRaises(TypeError, o.set_wal_ttl_seconds, None)
+
+    def test_set_wal_size_limit_mb(self):
+        o = Option()
+
+        self.assertIsNone(o.set_wal_size_limit_mb(64))
+        self.assertRaises(TypeError, o.set_wal_size_limit_mb, None)

--- a/test/option.py
+++ b/test/option.py
@@ -155,3 +155,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_zstd_max_train_bytes(64 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_zstd_max_train_bytes, None)
+
+    def test_set_bottommost_zstd_max_train_bytes(self):
+        o = Option()
+
+        self.assertIsNone(o.set_bottommost_zstd_max_train_bytes(64 * 1024 * 1024, True))
+        self.assertRaises(TypeError, o.set_bottommost_zstd_max_train_bytes, None, None)

--- a/test/option.py
+++ b/test/option.py
@@ -251,3 +251,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_target_file_size_multiplier(2))
         self.assertRaises(TypeError, o.set_target_file_size_multiplier, None)
+
+    def test_set_min_write_buffer_number(self):
+        o = Option()
+
+        self.assertIsNone(o.set_min_write_buffer_number(2))
+        self.assertRaises(TypeError, o.set_min_write_buffer_number, None)

--- a/test/option.py
+++ b/test/option.py
@@ -269,3 +269,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_db_write_buffer_size(512 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_db_write_buffer_size, None)
+
+    def test_set_max_manifest_file_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_max_manifest_file_size(20 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_max_manifest_file_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -419,3 +419,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_ratelimiter(1024 * 1024, 100 * 1000, 10))
         self.assertRaises(TypeError, o.set_ratelimiter, None, None, None)
+
+    def test_set_auto_tuned_ratelimiter(self):
+        o = Option()
+
+        self.assertIsNone(o.set_auto_tuned_ratelimiter(1024 * 1024, 100 * 1000, 10))
+        self.assertRaises(TypeError, o.set_auto_tuned_ratelimiter, None, None, None)

--- a/test/option.py
+++ b/test/option.py
@@ -443,3 +443,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_recycle_log_file_num(3))
         self.assertRaises(TypeError, o.set_recycle_log_file_num, None)
+
+    def test_set_soft_pending_compaction_bytes_limit(self):
+        o = Option()
+
+        self.assertIsNone(o.set_soft_pending_compaction_bytes_limit(96 * 1024 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_soft_pending_compaction_bytes_limit, None)

--- a/test/option.py
+++ b/test/option.py
@@ -425,3 +425,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_auto_tuned_ratelimiter(1024 * 1024, 100 * 1000, 10))
         self.assertRaises(TypeError, o.set_auto_tuned_ratelimiter, None, None, None)
+
+    def test_set_max_log_file_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_max_log_file_size(10 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_max_log_file_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -245,3 +245,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_is_fd_close_on_exec(False))
         self.assertRaises(TypeError, o.set_is_fd_close_on_exec, None)
+
+    def test_set_target_file_size_multiplier(self):
+        o = Option()
+
+        self.assertIsNone(o.set_target_file_size_multiplier(2))
+        self.assertRaises(TypeError, o.set_target_file_size_multiplier, None)

--- a/test/option.py
+++ b/test/option.py
@@ -347,3 +347,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_advise_random_on_open(False))
         self.assertRaises(TypeError, o.set_advise_random_on_open, None)
+
+    def test_set_use_adaptive_mutex(self):
+        o = Option()
+
+        self.assertIsNone(o.set_use_adaptive_mutex(True))
+        self.assertRaises(TypeError, o.set_use_adaptive_mutex, None)

--- a/test/option.py
+++ b/test/option.py
@@ -413,3 +413,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_atomic_flush(True))
         self.assertRaises(TypeError, o.set_atomic_flush, None)
+
+    def test_set_ratelimiter(self):
+        o = Option()
+
+        self.assertIsNone(o.set_ratelimiter(1024 * 1024, 100 * 1000, 10))
+        self.assertRaises(TypeError, o.set_ratelimiter, None, None, None)

--- a/test/option.py
+++ b/test/option.py
@@ -341,3 +341,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_stats_persist_period_sec(5))
         self.assertRaises(TypeError, o.set_stats_persist_period_sec, None)
+
+    def test_set_advise_random_on_open(self):
+        o = Option()
+
+        self.assertIsNone(o.set_advise_random_on_open(False))
+        self.assertRaises(TypeError, o.set_advise_random_on_open, None)

--- a/test/option.py
+++ b/test/option.py
@@ -497,3 +497,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_track_and_verify_wals_in_manifest(True))
         self.assertRaises(TypeError, o.set_track_and_verify_wals_in_manifest, None)
+
+    def test_get_track_and_verify_wals_in_manifest(self):
+        o = Option()
+
+        self.assertIsNotNone(o.get_track_and_verify_wals_in_manifest())
+        self.assertRaises(TypeError, o.get_track_and_verify_wals_in_manifest, None)

--- a/test/option.py
+++ b/test/option.py
@@ -293,3 +293,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_max_successive_merges(8))
         self.assertRaises(TypeError, o.set_max_successive_merges, None)
+
+    def test_set_inplace_update_support(self):
+        o = Option()
+
+        self.assertIsNone(o.set_inplace_update_support(True))
+        self.assertRaises(TypeError, o.set_inplace_update_support, None)

--- a/test/option.py
+++ b/test/option.py
@@ -119,3 +119,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.create_missing_column_families(True))
         self.assertRaises(TypeError, o.create_missing_column_families, None)
+
+    def test_set_error_if_exists(self):
+        o = Option()
+
+        self.assertIsNone(o.set_error_if_exists(True))
+        self.assertRaises(TypeError, o.set_error_if_exists, None)

--- a/test/option.py
+++ b/test/option.py
@@ -389,3 +389,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_skip_stats_update_on_db_open(True))
         self.assertRaises(TypeError, o.set_skip_stats_update_on_db_open, None)
+
+    def test_set_keep_log_file_num(self):
+        o = Option()
+
+        self.assertIsNone(o.set_keep_log_file_num(2_500))
+        self.assertRaises(TypeError, o.set_keep_log_file_num, None)

--- a/test/option.py
+++ b/test/option.py
@@ -215,3 +215,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_allow_concurrent_memtable_write(False))
         self.assertRaises(TypeError, o.set_allow_concurrent_memtable_write, None)
+
+    def test_set_enable_write_thread_adaptive_yield(self):
+        o = Option()
+
+        self.assertIsNone(o.set_enable_write_thread_adaptive_yield(False))
+        self.assertRaises(TypeError, o.set_enable_write_thread_adaptive_yield, None)

--- a/test/option.py
+++ b/test/option.py
@@ -431,3 +431,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_max_log_file_size(10 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_max_log_file_size, None)
+
+    def test_set_log_file_time_to_roll(self):
+        o = Option()
+
+        self.assertIsNone(o.set_log_file_time_to_roll(86_400))
+        self.assertRaises(TypeError, o.set_log_file_time_to_roll, None)

--- a/test/option.py
+++ b/test/option.py
@@ -305,3 +305,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_inplace_update_locks(25_000))
         self.assertRaises(TypeError, o.set_inplace_update_locks, None)
+
+    def test_set_max_write_buffer_size_to_maintain(self):
+        o = Option()
+
+        self.assertIsNone(o.set_max_write_buffer_size_to_maintain(20_000))
+        self.assertRaises(TypeError, o.set_max_write_buffer_size_to_maintain, None)

--- a/test/option.py
+++ b/test/option.py
@@ -509,3 +509,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_write_dbid_to_manifest(False))
         self.assertRaises(TypeError, o.set_write_dbid_to_manifest, None)
+
+    def test_get_write_dbid_to_manifest(self):
+        o = Option()
+
+        self.assertIsNotNone(o.get_write_dbid_to_manifest())
+        self.assertRaises(TypeError, o.get_write_dbid_to_manifest, None)

--- a/test/option.py
+++ b/test/option.py
@@ -161,3 +161,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_bottommost_zstd_max_train_bytes(64 * 1024 * 1024, True))
         self.assertRaises(TypeError, o.set_bottommost_zstd_max_train_bytes, None, None)
+
+    def test_set_compaction_readahead_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_compaction_readahead_size(16 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_compaction_readahead_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -149,3 +149,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_bottommost_compression_options(4, 5, 6, 7, True))
         self.assertRaises(TypeError, o.set_bottommost_compression_options, None, None, None, None, None)
+
+    def test_set_zstd_max_train_bytes(self):
+        o = Option()
+
+        self.assertIsNone(o.set_zstd_max_train_bytes(64 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_zstd_max_train_bytes, None)

--- a/test/option.py
+++ b/test/option.py
@@ -209,3 +209,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_writable_file_max_buffer_size(4096 * 1024))
         self.assertRaises(TypeError, o.set_writable_file_max_buffer_size, None)
+
+    def test_set_allow_concurrent_memtable_write(self):
+        o = Option()
+
+        self.assertIsNone(o.set_allow_concurrent_memtable_write(False))
+        self.assertRaises(TypeError, o.set_allow_concurrent_memtable_write, None)

--- a/test/option.py
+++ b/test/option.py
@@ -383,3 +383,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_manifest_preallocation_size(8 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_manifest_preallocation_size, None)
+
+    def test_set_skip_stats_update_on_db_open(self):
+        o = Option()
+
+        self.assertIsNone(o.set_skip_stats_update_on_db_open(True))
+        self.assertRaises(TypeError, o.set_skip_stats_update_on_db_open, None)

--- a/test/option.py
+++ b/test/option.py
@@ -203,3 +203,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_wal_bytes_per_sync(1 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_wal_bytes_per_sync, None)
+
+    def test_set_writable_file_max_buffer_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_writable_file_max_buffer_size(4096 * 1024))
+        self.assertRaises(TypeError, o.set_writable_file_max_buffer_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -125,3 +125,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_error_if_exists(True))
         self.assertRaises(TypeError, o.set_error_if_exists, None)
+
+    def test_set_paranoid_checks(self):
+        o = Option()
+
+        self.assertIsNone(o.set_paranoid_checks(True))
+        self.assertRaises(TypeError, o.set_paranoid_checks, None)

--- a/test/option.py
+++ b/test/option.py
@@ -503,3 +503,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNotNone(o.get_track_and_verify_wals_in_manifest())
         self.assertRaises(TypeError, o.get_track_and_verify_wals_in_manifest, None)
+
+    def test_set_write_dbid_to_manifest(self):
+        o = Option()
+
+        self.assertIsNone(o.set_write_dbid_to_manifest(False))
+        self.assertRaises(TypeError, o.set_write_dbid_to_manifest, None)

--- a/test/option.py
+++ b/test/option.py
@@ -221,3 +221,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_enable_write_thread_adaptive_yield(False))
         self.assertRaises(TypeError, o.set_enable_write_thread_adaptive_yield, None)
+
+    def test_set_max_sequential_skip_in_iterations(self):
+        o = Option()
+
+        self.assertIsNone(o.set_max_sequential_skip_in_iterations(16))
+        self.assertRaises(TypeError, o.set_max_sequential_skip_in_iterations, None)

--- a/test/option.py
+++ b/test/option.py
@@ -107,3 +107,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.optimize_level_style_compaction(0x40000))
         self.assertRaises(TypeError, o.optimize_level_style_compaction, 1.024)
+
+    def test_optimize_universal_style_compaction(self):
+        o = Option()
+
+        self.assertIsNone(o.optimize_universal_style_compaction(0x40000))
+        self.assertRaises(TypeError, o.optimize_universal_style_compaction, 1.024)

--- a/test/option.py
+++ b/test/option.py
@@ -94,3 +94,10 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_level_zero_slowdown_writes_trigger(10))
         self.assertRaises(TypeError, o.set_level_zero_slowdown_writes_trigger, None)
+
+    def test_increase_parallelism(self):
+        o = Option()
+
+        self.assertIsNone(o.increase_parallelism(2))
+        self.assertRaises(TypeError, o.increase_parallelism, 1.1)
+        self.assertRaises(TypeError, o.increase_parallelism, None)

--- a/test/option.py
+++ b/test/option.py
@@ -407,3 +407,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_manual_wal_flush(True))
         self.assertRaises(TypeError, o.set_manual_wal_flush, None)
+
+    def test_set_atomic_flush(self):
+        o = Option()
+
+        self.assertIsNone(o.set_atomic_flush(True))
+        self.assertRaises(TypeError, o.set_atomic_flush, None)

--- a/test/option.py
+++ b/test/option.py
@@ -395,3 +395,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_keep_log_file_num(2_500))
         self.assertRaises(TypeError, o.set_keep_log_file_num, None)
+
+    def test_set_allow_mmap_writes(self):
+        o = Option()
+
+        self.assertIsNone(o.set_allow_mmap_writes(True))
+        self.assertRaises(TypeError, o.set_allow_mmap_writes, None)

--- a/test/option.py
+++ b/test/option.py
@@ -479,3 +479,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_enable_blob_files(True))
         self.assertRaises(TypeError, o.set_enable_blob_files, None)
+
+    def test_set_allow_ingest_behind(self):
+        o = Option()
+
+        self.assertIsNone(o.set_allow_ingest_behind(True))
+        self.assertRaises(TypeError, o.set_allow_ingest_behind, None)

--- a/test/option.py
+++ b/test/option.py
@@ -263,3 +263,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_db_write_buffer_size(128 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_db_write_buffer_size, None)
+
+    def test_set_max_bytes_for_level_base(self):
+        o = Option()
+
+        self.assertIsNone(o.set_db_write_buffer_size(512 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_db_write_buffer_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -323,3 +323,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_report_bg_io_stats(True))
         self.assertRaises(TypeError, o.set_report_bg_io_stats, None)
+
+    def test_set_max_total_wal_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_max_total_wal_size(1 << 30))
+        self.assertRaises(TypeError, o.set_max_total_wal_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -401,3 +401,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_allow_mmap_writes(True))
         self.assertRaises(TypeError, o.set_allow_mmap_writes, None)
+
+    def test_set_manual_wal_flush(self):
+        o = Option()
+
+        self.assertIsNone(o.set_manual_wal_flush(True))
+        self.assertRaises(TypeError, o.set_manual_wal_flush, None)

--- a/test/option.py
+++ b/test/option.py
@@ -437,3 +437,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_log_file_time_to_roll(86_400))
         self.assertRaises(TypeError, o.set_log_file_time_to_roll, None)
+
+    def test_set_recycle_log_file_num(self):
+        o = Option()
+
+        self.assertIsNone(o.set_recycle_log_file_num(3))
+        self.assertRaises(TypeError, o.set_recycle_log_file_num, None)

--- a/test/option.py
+++ b/test/option.py
@@ -353,3 +353,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_use_adaptive_mutex(True))
         self.assertRaises(TypeError, o.set_use_adaptive_mutex, None)
+
+    def test_set_memtable_prefix_bloom_ratio(self):
+        o = Option()
+
+        self.assertIsNone(o.set_memtable_prefix_bloom_ratio(0.2))
+        self.assertRaises(TypeError, o.set_memtable_prefix_bloom_ratio, None)

--- a/test/option.py
+++ b/test/option.py
@@ -143,3 +143,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_compression_options(4, 5, 6, 7))
         self.assertRaises(TypeError, o.set_compression_options, None, None, None, None)
+
+    def test_set_bottommost_compression_options(self):
+        o = Option()
+
+        self.assertIsNone(o.set_bottommost_compression_options(4, 5, 6, 7, True))
+        self.assertRaises(TypeError, o.set_bottommost_compression_options, None, None, None, None, None)

--- a/test/option.py
+++ b/test/option.py
@@ -179,3 +179,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_optimize_filters_for_hits(True))
         self.assertRaises(TypeError, o.set_optimize_filters_for_hits, None)
+
+    def test_set_delete_obsolete_files_period_micros(self):
+        o = Option()
+
+        self.assertIsNone(o.set_delete_obsolete_files_period_micros(300_000_000))
+        self.assertRaises(TypeError, o.set_delete_obsolete_files_period_micros, None)

--- a/test/option.py
+++ b/test/option.py
@@ -455,3 +455,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_hard_pending_compaction_bytes_limit(512 * 1024 * 1024 * 1024))
         self.assertRaises(TypeError, o.set_hard_pending_compaction_bytes_limit, None)
+
+    def test_set_arena_block_size(self):
+        o = Option()
+
+        self.assertIsNone(o.set_arena_block_size(32 * 1024 * 1024))
+        self.assertRaises(TypeError, o.set_arena_block_size, None)

--- a/test/option.py
+++ b/test/option.py
@@ -287,3 +287,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_memtable_huge_page_size(20))
         self.assertRaises(TypeError, o.set_memtable_huge_page_size, None)
+
+    def test_set_max_successive_merges(self):
+        o = Option()
+
+        self.assertIsNone(o.set_max_successive_merges(8))
+        self.assertRaises(TypeError, o.set_max_successive_merges, None)

--- a/test/option.py
+++ b/test/option.py
@@ -473,3 +473,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_memtable_whole_key_filtering(True))
         self.assertRaises(TypeError, o.set_memtable_whole_key_filtering, None)
+
+    def test_set_enable_blob_files(self):
+        o = Option()
+
+        self.assertIsNone(o.set_enable_blob_files(True))
+        self.assertRaises(TypeError, o.set_enable_blob_files, None)

--- a/test/option.py
+++ b/test/option.py
@@ -227,3 +227,9 @@ class TestOption(unittest.TestCase):
 
         self.assertIsNone(o.set_max_sequential_skip_in_iterations(16))
         self.assertRaises(TypeError, o.set_max_sequential_skip_in_iterations, None)
+
+    def test_set_use_direct_reads(self):
+        o = Option()
+
+        self.assertIsNone(o.set_use_direct_reads(True))
+        self.assertRaises(TypeError, o.set_use_direct_reads, None)


### PR DESCRIPTION
Thanks for this Python package. I noticed it was lacking some features so this PR adds some of those. I had first started making separate commits for each new function *and* test, but I later joined each into 1 commit. This pull request adds some new options/functions to the `Option()` class. Some options/functions are not added due to being more complicated than just requiring some parameters that can be implemented in Python.

*Forgive me for not adding links to these, it's a lot of manual copy and paste 😅.*
## Added options/features to the `Option()` class:
- increase_parallelism
- optimize_level_style_compaction
- optimize_universal_style_compaction
- create_missing_column_families
- set_error_if_exists
- set_paranoid_checks
- set_compression_options_parallel_threads
- set_compression_options
- set_bottommost_compression_options
- set_zstd_max_train_bytes
- set_bottommost_zstd_max_train_bytes
- set_compaction_readahead_size
- set_level_compaction_dynamic_level_bytes
- set_optimize_filters_for_hits
- set_delete_obsolete_files_period_micros
- set_max_file_opening_threads
- set_wal_bytes_per_sync
- set_writable_file_max_buffer_size
- set_allow_concurrent_memtable_write
- set_enable_write_thread_adaptive_yield
- set_max_sequential_skip_in_iterations
- set_use_direct_reads
- set_use_direct_io_for_flush_and_compaction
- set_target_file_size_multiplier
- set_min_write_buffer_number
- set_db_write_buffer_size
- set_max_bytes_for_level_base
- set_max_manifest_file_size
- set_level_zero_file_num_compaction_trigger
- set_memtable_huge_page_size
- set_max_successive_merges
- set_inplace_update
- set_inplace_update_locks
- set_max_write_buffer_size_to_maintain
- set_enable_pipelined_write
- set_report_bg_io_stats
- set_max_total_wal_size
- set_stats_dump_period_sec
- set_stats_persist_period_sec
- set_advise_random_on_open
- set_stats_persist_period_sec
- set_use_adaptive_mutex
- set_memtable_prefix_bool_ratio
- set_max_compaction_bytes
- set_wal_size_limit_mb
- test_set_manifest_preallocation_size
- set_skip_stats_update_on_db_open
- set_keep_log_file_num
- set_allow_mmap_writes
- set_manual_wal_flush
- set_atomic_flush
- set_ratelimiter
- set_autotuned_ratelimiter
- set_max_log_file_size
- set_log_file_time_to_roll
- set_recycle_log_file_num
- set_soft_pending_compaction_bytes_limit
- set_hard_pending_compaction_bytes_limit
- set_arena_block_size
- set_dump_malloc_stats
- set_memtable_whole_key_filtering
- set_enable_blob_files
- set_allow_ingest_behind
- set_avoid_unnecessary_blocking_io
- set_track_and_verify_wals_in_manifest
- get_track_and_verify_wals_in_manifest
- set_write_dbid_to_manifest
- get_write_dbid_to_manifest

## Skipped features (links added for easy documentation access):
- load_latest [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.load_latest)
- set_db_paths [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_db_paths)
- set_env [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_env)
- set_compression_type [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_compression_type)
- set_wal_compression_type [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_wal_compression_type)
- set_bottommost_compression_type [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_bottommost_compression_type)
- set_compression_per_level [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_compression_per_level)
- set_periodic_compaction_seconds [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_periodic_compaction_seconds)
- set_merge_operator_associative [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_merge_operator_associative)
- set_merge_operator [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_merge_operator)
- add_merge_operator (deprecated 0.5.0 alias) [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.add_merge_operator)
- set_compaction_filter [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_compaction_filter)
- set_compaction_filter_factory [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_compaction_filter_factory)
- set_comparator [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_comparator)
- set_comparator_with_ts [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_comparator_with_ts)
- set_prefix_extractor [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_prefix_extractor)
- get_use_fsync [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.get_use_fsync)
- set_db_log_dir [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_db_log_dir)
- set_log_level [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_log_level)
- set_allow_os_buffer (deprecated 0.7.0 alias) [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_allow_os_buffer)
- set_max_bytes_for_level_multiplier [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_max_bytes_for_level_multiplier)
- set_compaction_pri [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_compaction_pri)
- set_universal_compaction_options [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_universal_compaction_options)
- set_fifo_compaction_options [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_fifo_compaction_options)
- set_max_background_compactions (deprecated 0.15.0, automatic by db) [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_max_background_compactions)
- set_max_background_flushes (deprecated since 0.15.0, automatic by db) [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_max_background_flushes)
- set_max_bytes_for_level_multiplier_additional [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_max_bytes_for_level_multiplier_additional)
- set_skip_checking_sst_file_sizes_on_db_open (deprecated since RocksDB >= 10.5, checked using thread pool) [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_skip_checking_sst_file_sizes_on_db_open)
- set_memtable_factory [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_memtable_factory)
- set_block_based_table_factory [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_block_based_table_factory)
- set_cuckoo_table_factory [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_cuckoo_table_factory)
- set_plain_table_factory [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_plain_table_factory)
- set_min_level_to_compress [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_min_level_to_compress)
- set_wal_recovery_mode [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_wal_recovery_mode)
- enable_statistics [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.enable_statistics)
- set_statistics_level [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_statistics_level)
- get_ticker_count [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.get_ticker_count)
- get_histogram_data [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.get_histogram_data)
- set_num_levels [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_num_levels)
- set_wal_dir [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_wal_dir)
- set_row_cache [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_row_cache)
- set_min_blob_size [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_min_blob_size)
- set_blob_file_size [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_blob_file_size)
- set_blob_compression_type [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_blob_compression_type)
- set_enable_blob_gc [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_enable_blob_gc)
- set_blob_gc_age_cutoff [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_blob_gc_age_cutoff)
- set_blob_gc_force_threshold [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_blob_gc_force_threshold)
- set_blob_compaction_readahead_size [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_blob_compaction_readahead_size)
- set_blob_cache [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_blob_cache)
- add_compact_on_deletion_collector_factory [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.add_compact_on_deletion_collector_factory)
- set_write_buffer_manager [link](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_write_buffer_manager)

For each function I added, a unit test was also added. The tests aren't perfect (and do not catch most edge cases), but I did my best to match the style of what already existed. There are also some other caveats with the added features:
- Some features do not have default values, those were marked as `Default: N/A` in source code.
- Using `c_int` as a parameter will **not** let the library compile. The rust documentation for `c_int` ([link](https://docs.rs/libc/0.2.174/libc/type.c_int.html)) uses it as an alias for `i32`, so I used that instead for functions that require it.
- Using `size_t` as a parameter will **not** let the library compile. The rust documentation for `size_t` ([link](https://docs.rs/libc/0.2.174/libc/type.size_t.html)) uses it as an alias for `usize`, so I used that instead for functions that require it.
- Using `c_uint` as a parameter will **not** let the library compile. The rust documentation for `c_uint` ([link](https://doc.rust-lang.org/std/ffi/type.c_uint.html)) uses it (sometimes) as an alias for `u32`, so I used that instead for functions that require it.
- Some features do not have examples, so I made my own based on existing examples and made up examples for ones that didn't have any.
- Some features do not have descriptions on the documentation, so source code comments were used to describe it if possible (some lines use double `/` (`//`) instead of triple `/` (`///`) so they didn't appear in the documentation). Otherwise the feature was skipped.
- Some features have "descriptions", but they are very vague and only include the name of the function (like [set_optimize_filters_for_hits](https://docs.rs/rocksdb/0.24.0/rocksdb/struct.Options.html#method.set_optimize_filters_for_hits)).
- Some feature descriptions include "rust language". The descriptions mention calls like `DB::Open()` and they aren't currently changed to fit the Python version.

For code style, I had the following issues:
- Some existing functions do not have the ` ``` ` syntax for examples, but I didn't modify them as they aren't the goal of this PR.
- Some existing functions use markdown headings for marking examples, but I didn't modify them for the same reason as above.
- In the rocksdb rust documentation, it uses [smart quotes](https://www.youtube.com/watch?v=EJvG15vRVe0) (the "Apple" way of quotations). I replaced all of them that I could find with Unicode quotes (`'` and `"`).
- Examples all use lowercase typing for booleans, but Python uses capital letters (`True` and `False`). I didn't modify this as some existing functions used this same style (but it should be considered).

Some of the functions (but very few of them) added to `Option()` are experimental or depend on other functions that are not implemented. I think it's better to leave them in here for now and if someone has an issue, they can file one so it can be implemented.

I do have some questions though about the project:
1. Is this project still being maintained?
2. What should be done about the feature + code style issues (no examples, no default values, no descriptions, etc.)
3. How much support do you want to have for RocksDB? (amount of functions/different features covered)
4. How soon are you planning to implement the features you answered in <span>#</span>3?